### PR TITLE
Scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ check_isa
 Test_Makefile
 testing_log_*
 gen_test_makefile_log_*
+statistics_*.log

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Several techniques are used to increase the probability of triggering compiler b
 Compiler bugs found by YARP Generator
 -------------------------------------
 
-``yarpgen`` managed to find more than 50 bugs in gcc and clang and a comparable number of bugs in proprietary compilers. For the list of the bugs in gcc and clang see bugs.txt.
+``yarpgen`` managed to find more than 60 bugs in gcc and clang and a comparable number of bugs in proprietary compilers. For the list of the bugs in gcc and clang see bugs.txt.
 
 If you have used ``yarpgen`` to find bugs in open source compilers, please update bugs.txt. We are aslo excited to hear about your experience using it with proprietary compilers and other tools you might want to validate.
 
@@ -26,7 +26,7 @@ Building and running
 
 Building ``yarpgen`` is trivial.  All you have to do is invoke "make".
 
-To run ``yarpgen`` we recommend using ``run_gen.py`` script, which will run the generator for you on a number of available compilers with a set of pre-defined options. Feel free to hack run_gen.py and Test_Makefile to add or remove compiler options.
+To run ``yarpgen`` we recommend using ``run_gen.py`` script, which will run the generator for you on a number of available compilers with a set of pre-defined options. Feel free to hack test_set.txt to add or remove compiler options.
 
 The script will run several compilers with several compiler options and run executables to compare the output results. If the results mismatch, the test program will be saved in "results" folder for your analysis.
 

--- a/blame_opt.py
+++ b/blame_opt.py
@@ -82,7 +82,7 @@ def execute_blame_phase(valid_res, fail_target, inject_str, num, phase_num):
         failed_flag = False
         eff = ((start_opt + 1) == cur_opt)  # Earliest fail was found
 
-        common.log_msg(logging.DEBUG, "Trying opt: " + str(start_opt) + "/" + str(cur_opt) + "/" + str(end_opt))
+        common.log_msg(logging.DEBUG, "Trying opt (process " + str(num) + "): " + str(start_opt) + "/" + str(cur_opt) + "/" + str(end_opt))
         gen_test_makefile.gen_makefile(blame_test_makefile_name, True, None, fail_target, inject_str + str(cur_opt))
 
         ret_code, output, err_output, time_expired, elapsed_time = \
@@ -114,10 +114,10 @@ def execute_blame_phase(valid_res, fail_target, inject_str, num, phase_num):
                 break
 
         time_to_finish = (eff and failed_flag) or (eff and not failed_flag and (cur_opt == (end_opt - 1)))
-        common.log_msg(logging.DEBUG, "Time to finish: " + str(time_to_finish))
+        common.log_msg(logging.DEBUG, "Time to finish (process " + str(num) + "): " + str(time_to_finish))
 
     if not failed_flag:
-        common.log_msg(logging.DEBUG, "Swapping current and end opt")
+        common.log_msg(logging.DEBUG, "Swapping current and end opt (process " + str(num) + ")")
         cur_opt = end_opt
 
     return str(cur_opt)

--- a/bugs.txt
+++ b/bugs.txt
@@ -30,6 +30,7 @@ LLVM:
 25517 - [AVX-512] llc generates incorrect code
 
 GCC:
+78726 - [5/6 Regression] Incorrect unsigned arithmetic optimization
 78720 - [7 Regression] Illegal instruction in generated code
 78438 - [7 Regression] incorrect comparison optimization
 78436 - [7 Regression] incorrect write to larger-than-type bitfield (signed char x:9)

--- a/common.py
+++ b/common.py
@@ -31,7 +31,7 @@ import sys
 
 # $YARPGEN_HOME environment variable should be set to YARP Generator directory
 yarpgen_home = os.environ["YARPGEN_HOME"] if "YARPGEN_HOME" in os.environ else os.getcwd()
-yarpgen_version = ""
+yarpgen_version_str = ""
 
 main_logger_name = "main_logger"
 main_logger = None

--- a/common.py
+++ b/common.py
@@ -197,3 +197,10 @@ def if_exec_exist(program):
                 return True
     log_msg(logging.DEBUG, "Exec wasn't found")
     return False
+
+def clean_dir(path):
+    for root, dirs, files in os.walk(path, topdown=False):
+        for name in files:
+            os.remove(os.path.join(root, name))
+        for name in dirs:
+            os.rmdir(os.path.join(root, name))

--- a/common.py
+++ b/common.py
@@ -91,8 +91,9 @@ class StatisticsFileHandler(logging.FileHandler):
 def setup_stat_logger(log_file):
     global stat_logger
     stat_logger = logging.getLogger(stat_logger_name)
-    stat_handler = StatisticsFileHandler(filename=log_file, mode="w", delay=True)
-    stat_logger.addHandler(stat_handler)
+    if log_file is not None:
+        stat_handler = StatisticsFileHandler(filename=log_file, mode="w", delay=True)
+        stat_logger.addHandler(stat_handler)
     stat_logger.setLevel(logging.INFO)
 
 

--- a/common.py
+++ b/common.py
@@ -151,7 +151,7 @@ def check_dir_and_create(directory):
 
 
 def run_cmd(cmd, time_out=None, num=-1):
-    time_expired = False
+    is_time_expired = False
     start_time = os.times()
     with subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as process:
         try:
@@ -165,7 +165,7 @@ def run_cmd(cmd, time_out=None, num=-1):
             process.kill()
             log_msg(logging.DEBUG, str(cmd) + " failed")
             output, err_output = process.communicate()
-            time_expired = True
+            is_time_expired = True
             ret_code = None
         except:
             log_msg(logging.ERROR, str(cmd) + " failed: unknown exception")
@@ -175,7 +175,7 @@ def run_cmd(cmd, time_out=None, num=-1):
     end_time = os.times()
     elapsed_time = end_time.children_user - start_time.children_user + \
                    end_time.children_system - start_time.children_system
-    return ret_code, output, err_output, time_expired, elapsed_time
+    return ret_code, output, err_output, is_time_expired, elapsed_time
 
 
 def if_exec_exist(program):

--- a/gen_test_makefile.py
+++ b/gen_test_makefile.py
@@ -224,11 +224,11 @@ def detect_native_arch():
         if not os.path.exists(check_isa_file):
             common.print_and_exit("Can't find " + check_isa_file)
         ret_code, output, err_output, time_expired, elapsed_time = \
-            common.run_cmd([sys_compiler, check_isa_file, "-o", check_isa_binary], None, 0)
+            common.run_cmd([sys_compiler, check_isa_file, "-o", check_isa_binary], None)
         if ret_code != 0:
             common.print_and_exit("Can't compile " + check_isa_file + ": " + str(err_output, "utf-8"))
 
-    ret_code, output, err_output, time_expired, elapsed_time = common.run_cmd([check_isa_binary], None, 0)
+    ret_code, output, err_output, time_expired, elapsed_time = common.run_cmd([check_isa_binary], None)
     if ret_code != 0:
         common.print_and_exit("Error while executing " + check_isa_binary)
     native_arch_str = str(output, "utf-8").split()[0]

--- a/gen_test_makefile.py
+++ b/gen_test_makefile.py
@@ -283,10 +283,12 @@ def gen_makefile(out_file_name, force, config_file, only_target=None, inject_bla
     
     for source in sources.value.split():
         source_prefix = ""
+        force_str = " FORCE\n"
         if creduce_file and creduce_file != source:
             source_prefix = "$(TEST_PWD)/"
+            force_str = "\n"
         source_name = source.split(".")[0]
-        output += "%" + source_name + ".o: " + source_prefix + source + " FORCE\n"
+        output += "%" + source_name + ".o: " + source_prefix + source + force_str
         output += "\t" + "$(COMPILER) $(CXXFLAGS) $(OPTFLAGS) -o $@ -c $<"
         if inject_blame_opt is not None and source_name == "func":
             output += " $(BLAMEOPTS)"

--- a/run_gen.py
+++ b/run_gen.py
@@ -713,6 +713,8 @@ def proccess_seeds(seeds_option_value):
         seeds_file = common.check_and_open_file(seeds[0], "r")
         seeds = []
         for line in seeds_file:
+            if line.lstrip().startswith("#"):
+                continue
             seeds += process_seed_line(line)
     else:
         seeds = process_seed_line(seeds_option_value)
@@ -951,7 +953,8 @@ Use specified folder for testing
     parser.add_argument("--seeds", dest="seeds_option_value", default="", type=str,
                         help="List of generator seeds to run or a file name with the list of seeds. "\
                              "Seeds may be separated by whitespaces and commas."\
-                             "The seed may start with S_ or end with /, i.e. S_12345/ is interpretted as 12345.")
+                             "The seed may start with S_ or end with /, i.e. S_12345/ is interpretted as 12345."
+                             "File comments may start with #")
     args = parser.parse_args()
 
     log_level = logging.DEBUG if args.verbose else logging.INFO

--- a/run_gen.py
+++ b/run_gen.py
@@ -46,7 +46,7 @@ yarpgen_timeout = 60
 compiler_timeout = 600
 run_timeout = 300
 stat_update_delay = 10
-creduce_timeout = 3600 * 6
+creduce_timeout = 3600 * 24
 
 script_start_time = datetime.datetime.now()  # We should init variable, so let's do it this way
 
@@ -438,7 +438,7 @@ class Test(object):
         self.files.append(test_sh_file.name)
 
         # Run creduce
-        cr_params_list = ["creduce", "--timing", os.path.abspath(test_sh_file.name), "func.cpp"]
+        cr_params_list = [creduce_bin, "--timing", "--timeout", str((run_timeout+compiler_timeout)*2), os.path.abspath(test_sh_file.name), "func.cpp"]
         cr_cmd = " ".join(str(p) for p in cr_params_list)
         cr_ret_code, cr_stdout, cr_stderr, cr_is_time_expired, cr_elapsed_time = \
             common.run_cmd(cr_params_list, creduce_timeout, self.proc_num)
@@ -998,6 +998,7 @@ def proccess_seeds(seeds_option_value):
     else:
         seeds = process_seed_line(seeds_option_value)
     unique_seeds = list(set(seeds))
+    unique_seeds.sort()
     common.log_msg(logging.INFO, "Running generator for "+str(len(unique_seeds))+" seeds. Seed are: ", forced_duplication=True);
     common.log_msg(logging.INFO, unique_seeds, forced_duplication=True)
     if len(unique_seeds) != len(seeds):
@@ -1041,6 +1042,8 @@ def prepare_env_and_start_testing(out_dir, timeout, targets, num_jobs, config_fi
         task_queue = multiprocessing.Queue()
         for s in seeds:
             task_queue.put(s)
+        if len(seeds) < num_jobs:
+            num_jobs = len(seeds)
 
     print_compilers_version(targets)
 

--- a/run_gen.py
+++ b/run_gen.py
@@ -200,7 +200,7 @@ class Test(object):
         if build_fail:
             build_fail.save(lock)
         if run_fail:
-            if self.blame and len(self.successful_test_runs) > 0:
+            if self.blame and len(self.successful_test_runs) > 0 and run_fail.status == TestRun.STATUS_runfail:
                 do_blame(run_fail, self.files, self.successful_test_runs[0].checksum, run_fail.target)
             run_fail.save(lock)
 

--- a/run_gen.py
+++ b/run_gen.py
@@ -469,10 +469,11 @@ def gen_test_makefile_and_copy(dest, config_file):
 
 
 def dump_testing_sets(targets):
-    common.log_msg(logging.INFO, "Testing sets: ")
+    test_sets = []
     for i in gen_test_makefile.CompilerTarget.all_targets:
         if i.specs.name in targets.split():
-            common.log_msg(logging.INFO, i.name, forced_duplication=True)
+            test_sets.append(i.name)
+    common.log_msg(logging.INFO, "Running "+str(len(test_sets))+" test sets: "+ str(test_sets), forced_duplication=True)
 
 
 def print_compilers_version(targets):
@@ -508,23 +509,12 @@ def proccess_seeds(seeds_option_value):
             seeds += process_seed_line(line)
     else:
         seeds = process_seed_line(seeds_option_value)
-    common.log_msg(logging.DEBUG, "Running generator for "+str(len(seeds))+" seeds. Seed are:");
-    common.log_msg(logging.DEBUG, seeds)
+    common.log_msg(logging.INFO, "Running generator for "+str(len(seeds))+" seeds. Seed are: ", forced_duplication=True);
+    common.log_msg(logging.INFO, seeds, forced_duplication=True)
     return seeds
 
 def prepare_env_and_start_testing(out_dir, timeout, targets, num_jobs, config_file, seeds_option_value):
     common.check_dir_and_create(out_dir)
-
-    seeds = []
-    task_queue = None
-    if seeds_option_value:
-        seeds = proccess_seeds(seeds_option_value)
-        task_queue = multiprocessing.Queue()
-        for s in seeds:
-            task_queue.put(s)
-#        for num in range(num_jobs):
-#            task_queue.put(None)
-
 
     # Check for binary of generator
     yarpgen_bin = os.path.abspath(common.yarpgen_home + os.sep + "yarpgen")
@@ -537,6 +527,14 @@ def prepare_env_and_start_testing(out_dir, timeout, targets, num_jobs, config_fi
     test_makefile_location = gen_test_makefile_and_copy(out_dir, config_file)
 
     dump_testing_sets(targets)
+
+    seeds = []
+    task_queue = None
+    if seeds_option_value:
+        seeds = proccess_seeds(seeds_option_value)
+        task_queue = multiprocessing.Queue()
+        for s in seeds:
+            task_queue.put(s)
 
     print_compilers_version(targets)
 

--- a/run_gen.py
+++ b/run_gen.py
@@ -239,19 +239,13 @@ class Test(object):
         for run in (bad_runs + good_runs):
             files_to_save.append(run.exe_file)
         cmplr_set = []
-        optset_set = []
         for run in bad_runs:
             cmplr_set.append(run.target.specs.name)
-            optset_set.append(run.optset)
         cmplr = "-".join(c for c in cmplr_set)
-        optset = "-".join(o for o in optset_set)
-        if len(cmplr_set) == 1:
-            optset = optset.replace(cmplr+"_", "")
 
         save_test2(lock, files_to_save,
                    compiler_name = cmplr,
                    fail_type = self.status_string(),
-                   optset = optset,
                    classification = None,
                    test_name = "S_" + str(self.seed))
 
@@ -409,19 +403,10 @@ class TestRun(object):
         log = self.build_log()
         file_list.append(log)
 
-        optset_set = []
-        optset_set.append(self.optset)
-        for run in self.similar_fails:
-            optset_set.append(run.optset)
-        optset_set.sort()
-        optset = "-".join(o for o in optset_set)
-        optset = optset.replace(self.target.specs.name+"_", "")
-
         save_test2(lock,
                    file_list,
                    compiler_name=self.target.specs.name,
                    fail_type=save_status,
-                   optset=optset,
                    classification=classification,
                    test_name="S_"+str(self.test.seed))
 
@@ -827,19 +812,18 @@ def gen_and_test(num, lock, end_time, task_queue, stat, targets):
         test.handle_results(lock)
 
 
-# save file_list in compiler_name/fail_type/[optset]/[classification]/test_name
+# save file_list in compiler_name/fail_type/[classification]/test_name
 # for example:
 # - icc/miscompare/S_123456
-# - icc/miscompare/icc_bdw/SIMP/S_123456
+# - icc/miscompare/SIMP/S_123456
 # - clang/build_fail/assert_XXXX/S_123456
-# - gcc/miscompare/gcc_skx/S_123456
+# - gcc/miscompare/S_123456
 # - generator_fail/S_20161230_22_30
 # return dir name
-def save_test2(lock, file_list, compiler_name=None, fail_type=None, optset=None, classification=None, test_name=None):
+def save_test2(lock, file_list, compiler_name=None, fail_type=None, classification=None, test_name=None):
     dest = ".." + os.sep + res_dir + \
                   ((os.sep + compiler_name) if (compiler_name is not None) else "") + \
                   ((os.sep + fail_type) if (fail_type is not None) else os.sep + "script_problem") + \
-                  ((os.sep + optset) if (optset is not None) else "") + \
                   ((os.sep + classification) if (classification is not None) else "") + \
                   ((os.sep + test_name) if (test_name is not None) else os.sep + "FAIL_" + datetime.datetime.now().strftime('%Y%m%d_%H%M%S'))
     try:

--- a/run_gen.py
+++ b/run_gen.py
@@ -415,8 +415,6 @@ class Test(object):
 
         self.creduce_performance_hack()
 
-        creduce_makefile_abs_path = os.path.abspath(creduce_makefile_name)
-
         # Now we need to construct a Makefile and script for passing to creduce.
         # Need to make sure that -Werror=uninitialized is passed to the compiler.
         # Recommended flags:
@@ -424,10 +422,10 @@ class Test(object):
         test_sh = "#!/bin/bash\n\n"
         test_sh +="ulimit -t " + str(max(compiler_timeout, run_timeout)) + "\n\n"
         test_sh +="export TEST_PWD="+os.getcwd()+"\n\n"
-        test_sh +="make -f " + creduce_makefile_abs_path + " " + good_run.optset + " &&\\\n"
-        test_sh +="make -f " + creduce_makefile_abs_path + " run_" + good_run.optset + " > no_opt_out &&\\\n"
-        test_sh +="make -f " + creduce_makefile_abs_path + " " + bad_run.optset + " &&\\\n"
-        test_sh +="make -f " + creduce_makefile_abs_path + " run_" + bad_run.optset + " > opt_out &&\\\n"
+        test_sh +="make -f $TEST_PWD" + os.sep + creduce_makefile_name + " " + good_run.optset + " &&\\\n"
+        test_sh +="make -f $TEST_PWD" + os.sep + creduce_makefile_name + " run_" + good_run.optset + " > no_opt_out &&\\\n"
+        test_sh +="make -f $TEST_PWD" + os.sep + creduce_makefile_name + " " + bad_run.optset + " &&\\\n"
+        test_sh +="make -f $TEST_PWD" + os.sep + creduce_makefile_name + " run_" + bad_run.optset + " > opt_out &&\\\n"
         test_sh +="! diff no_opt_out opt_out"
         test_sh_file = open("test.sh", "w")
         test_sh_file.write(test_sh)

--- a/run_gen.py
+++ b/run_gen.py
@@ -391,6 +391,7 @@ def form_statistics(stat, targets, prev_len):
     total_cpu_duration = stat.get_yarpgen_duration()
     total_gen_errors = stat.get_yarpgen_runs(runfail_timeout)
     total_gen_errors += stat.get_yarpgen_runs(runfail)
+    total_seeds = stat.get_yarpgen_runs(total)
     total_runs = 0
     total_ok = 0
     total_runfail_timeout = 0
@@ -427,7 +428,7 @@ def form_statistics(stat, targets, prev_len):
                                     "{days} d {hours}:{minutes}:{seconds}") + " | "
     stat_str += "cpu time: " + strfdelta(total_cpu_duration, "{days} d {hours}:{minutes}:{seconds}") + " | "
     stat_str += testing_speed + " | "
-    stat_str += "target runs: " + str(total_runs) + " | "
+    stat_str += "seeds/targets: " + str(total_seeds)+"/"+str(total_runs) + " | "
     stat_str += "Errors: " + str(total_gen_errors) + "/"
     stat_str += str(total_compfail_timeout) + "/"
     stat_str += str(total_compfail) + "/"

--- a/run_gen.py
+++ b/run_gen.py
@@ -429,7 +429,7 @@ def form_statistics(stat, targets, prev_len):
     stat_str += "cpu time: " + strfdelta(total_cpu_duration, "{days} d {hours}:{minutes}:{seconds}") + " | "
     stat_str += testing_speed + " | "
     stat_str += "seeds/targets: " + str(total_seeds)+"/"+str(total_runs) + " | "
-    stat_str += "Errors: " + str(total_gen_errors) + "/"
+    stat_str += "Errors(g/ct/c/rt/r/d): " + str(total_gen_errors) + "/"
     stat_str += str(total_compfail_timeout) + "/"
     stat_str += str(total_compfail) + "/"
     stat_str += str(total_runfail_timeout) + "/"

--- a/run_gen.py
+++ b/run_gen.py
@@ -530,10 +530,12 @@ def do_blame(test_obj, test_files, good_result, target_to_blame):
             inplace = True)
         # Copy resuls back
         os.chdir(current_dir)
-        common.check_and_copy("blame/Blame_Makefile", ".")
-        common.check_and_copy("blame/log.txt", "./blame.log")
-        test_obj.files.append("Blame_Makefile")
-        test_obj.files.append("blame.log")
+        if os.path.exists("blame/Blame_Makefile"):
+            common.check_and_copy("blame/Blame_Makefile", ".")
+            test_obj.files.append("Blame_Makefile")
+        if os.path.exists("blame/log.txt"):
+            common.check_and_copy("blame/log.txt", "./blame.log")
+            test_obj.files.append("blame.log")
         # interpret results
         if type(blame_phase) is str:
             test_obj.blame_phase = blame_phase

--- a/run_gen.py
+++ b/run_gen.py
@@ -509,9 +509,12 @@ def proccess_seeds(seeds_option_value):
             seeds += process_seed_line(line)
     else:
         seeds = process_seed_line(seeds_option_value)
-    common.log_msg(logging.INFO, "Running generator for "+str(len(seeds))+" seeds. Seed are: ", forced_duplication=True);
-    common.log_msg(logging.INFO, seeds, forced_duplication=True)
-    return seeds
+    unique_seeds = list(set(seeds))
+    common.log_msg(logging.INFO, "Running generator for "+str(len(unique_seeds))+" seeds. Seed are: ", forced_duplication=True);
+    common.log_msg(logging.INFO, unique_seeds, forced_duplication=True)
+    if len(unique_seeds) != len(seeds):
+        common.log_msg(logging.INFO, "Note, that in the input seeds list there were "+str(len(seeds)-len(unique_seeds))+" duplicating seeds.", forced_duplication=True)
+    return unique_seeds
 
 def prepare_env_and_start_testing(out_dir, timeout, targets, num_jobs, config_file, seeds_option_value):
     common.check_dir_and_create(out_dir)

--- a/run_gen.py
+++ b/run_gen.py
@@ -1236,6 +1236,8 @@ Use specified folder for testing
     common.setup_logger(args.log_file, log_level)
 
     stat_log_file = common.wrap_log_file(args.stat_log_file, parser.get_default("stat_log_file"))
+    if len(args.seeds_option_value) != 0:
+        stat_log_file = None
     common.setup_stat_logger(stat_log_file)
 
     script_start_time = datetime.datetime.now()

--- a/src/master.cpp
+++ b/src/master.cpp
@@ -70,11 +70,14 @@ std::string Master::emit_init () {
 
 std::string Master::emit_decl () {
     std::string ret = "";
+    /* TODO: none of it is used currently.
+     * All these headers must be added only when they are really needed.
+     * Parsing these headers is costly for compile time
     ret += "#include <cstdint>\n";
-    ret += "#include <iostream>\n";
     ret += "#include <array>\n";
     ret += "#include <vector>\n";
     ret += "#include <valarray>\n\n";
+    */
 
     ret += "void hash(unsigned long long int &seed, unsigned long long int const &v);\n\n";
 
@@ -141,6 +144,7 @@ std::string Master::emit_check () { // TODO: rewrite with IR
 
 std::string Master::emit_main () {
     std::string ret = "";
+    ret += "#include <iostream>\n";
     ret += "#include \"init.h\"\n\n";
     ret += "extern void init ();\n";
     ret += "extern void foo ();\n";

--- a/test_sets.txt
+++ b/test_sets.txt
@@ -32,7 +32,8 @@ Compiler specs:
 gcc         | g++             | -w                                                          | -march=
 clang       | clang++         | -w                                                          | -march=
 #Ubsan it is clang with sanitizer options. It is used for generator check.
-ubsan       | clang++         | -O0 -fsanitize=undefined -fno-sanitize-recover=undefined -w | -march=
+ubsan_clang | clang++         | -fsanitize=undefined -fno-sanitize-recover=undefined -w -Werror=uninitialized | -march=
+ubsan_gcc   | g++             | -fsanitize=undefined -fno-sanitize-recover=undefined -w -Werror=uninitialized | -march=
 icc         | icpc            | -w                                                          | -x
 
 Testing sets:
@@ -43,7 +44,10 @@ Testing sets:
 # Sde arch - architecture which will be passed to SDE
 
 # Set name       | Spec name | Arguments | Compiler arch  | Sde arch
-ubsan            | ubsan     |           |                | 
+ubsan_clang_o0   | ubsan_clang | -O0       |                |
+#ubsan_clang_o2   | ubsan_clang | -O2       |                |
+ubsan_gcc_o0     | ubsan_gcc   | -O0       |                |
+#ubsan_gcc_o2     | ubsan_gcc   | -O2       |                |
 
 gcc_no_opt       | gcc       | -O0       | nehalem        | nhm
 gcc_wsm_opt      | gcc       | -O3       | westmere       | wsm


### PR DESCRIPTION
Bunch of script improvements. Now scripts support better logging in test directory, running run_gen.py for the list of seeds, automatic blaming for failed tests (for icc and clang), and support for automatic creduce run for failed tests with miscompared output.

Still missing features:
- creduce run for runfails and compfails.
- shell script in output directory for reproducing the fail (convenient for manual re-check).
- need more telemetry about test run in logs (run time, use memory, compiler versions).
- blaming feature needs bug fixes, it may hang for some tests.