### PR TITLE
Scripts improvements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Several techniques are used to increase the probability of triggering compiler b
 Compiler bugs found by YARP Generator
 -------------------------------------
 
-``yarpgen`` managed to find more than 70 bugs in gcc and clang and a comparable number of bugs in proprietary compilers. For the list of the bugs in gcc and clang see bugs.txt.
+``yarpgen`` managed to find more than 80 bugs in gcc and clang and a comparable number of bugs in proprietary compilers. For the list of the bugs in gcc and clang see bugs.txt.
 
 If you have used ``yarpgen`` to find bugs in open source compilers, please update bugs.txt. We are aslo excited to hear about your experience using it with proprietary compilers and other tools you might want to validate.
 

--- a/bugs.txt
+++ b/bugs.txt
@@ -1,4 +1,7 @@
 LLVM:
+32646 - UBSAN binary segfaults on correct UB-free test case.
+32525 - Assertion is hit: "The number of nodes scheduled doesn't match the expected number!"
+32515 - Assertion "DELETED_NODE in CSEMap!" fires a lot with -march=skx
 32345 - Assertion `Op.getScalarValueSizeInBits() == BitWidth && "Mask size mismatches value type size!"' failed with -O0.
 32340 - Assertion `N->getOpcode() != ISD::DELETED_NODE && "Deleted Node added to Worklist"' failed with -O0
 32329 - Silent failure in X86 DAG->DAG Instruction Selection with -march=skx -O3
@@ -37,8 +40,14 @@ LLVM:
 25517 - [AVX-512] llc generates incorrect code
 
 GCC:
+80403 - UBSAN: compile time crash with "type mismatch in binary expression" message in / and % expr
+80386 - UBSAN: false positive - constant folding and reassosiation before instrumentation
 80362 - [5/6 Regression] gcc miscompiles arithmetic with signed char
+80350 - UBSAN changes code semantics when -fno-sanitize-recover=undefined is used
+80349 - [6/7 Regression] UBSAN: compile time crash with "type mismatch in binary expression" message
+80348 - [6 Regression] UBSAN: compile time crash in ubsan_instrument_division
 80341 - [5/6 Regression] gcc miscompiles division of signed char
+80297 - [6 Regression] Compiler time crash: type mismatch in binary expression
 80072 - [7 Regression] ICE in gimple_build_assign_1 with -O3 -march=broadwell/skylake-avx512
 80067 - [6/7 Regression] ICE in fold_comparison with -fsanitize=undefined
 80054 - [7 Regression] ICE in verify_ssa with -O3 -march=broadwell/skylake-avx512

--- a/common.py
+++ b/common.py
@@ -76,7 +76,7 @@ def log_msg(log_level, message, forced_duplication = False):
     global main_logger
     main_logger.log(log_level, message)
     if __duplicate_err_to_stderr__ and (log_level == logging.ERROR or forced_duplication):
-        sys.stderr.write(str(message) + "\n")
+        sys.stderr.write("\n" + str(message) + "\n")
         sys.stderr.flush()
 
 

--- a/run_gen.py
+++ b/run_gen.py
@@ -66,7 +66,10 @@ known_build_fails = { \
     "VerifyScheduledSequence": "The number of nodes scheduled doesn't match the expected number", \
 # gcc
     "compute_live_loop_exits" : "compute_live_loop_exits", \
-    "verify_gimple" : "verify_gimple" \
+    "ubsan_instrument_division": "ubsan_instrument_division", \
+    "verify_gimple_assignment": "non-trivial conversion at assignment", \
+    "verify_gimple_shift": "type mismatch in shift expression", \
+    "verify_gimple_binary" : "type mismatch in binary expression" \
 }
 
 ###############################################################################

--- a/run_gen.py
+++ b/run_gen.py
@@ -41,6 +41,7 @@ import blame_opt
 res_dir = "result"
 process_dir = "process_"
 creduce_bin = "creduce"
+creduce_n = 0
 
 yarpgen_timeout = 60
 compiler_timeout = 1200
@@ -466,7 +467,7 @@ class Test(object):
         self.files.append(test_sh_file.name)
 
         # Run creduce
-        cr_params_list = [creduce_bin, "--timing", "--timeout", str((run_timeout+compiler_timeout)*2), os.path.abspath(test_sh_file.name), "func.cpp"]
+        cr_params_list = [creduce_bin, "--n", str(creduce_n), "--timing", "--timeout", str((run_timeout+compiler_timeout)*2), os.path.abspath(test_sh_file.name), "func.cpp"]
         cr_cmd = " ".join(str(p) for p in cr_params_list)
         cr_ret_code, cr_stdout, cr_stderr, cr_is_time_expired, cr_elapsed_time = \
             common.run_cmd(cr_params_list, creduce_timeout, self.proc_num)
@@ -547,7 +548,7 @@ class Test(object):
         self.files.append(test_sh_file.name)
 
         # Run creduce
-        cr_params_list = [creduce_bin, "--timing", "--timeout", str((run_timeout+compiler_timeout)*2), os.path.abspath(test_sh_file.name), "func.cpp"]
+        cr_params_list = [creduce_bin, "--n", str(creduce_n), "--timing", "--timeout", str((run_timeout+compiler_timeout)*2), os.path.abspath(test_sh_file.name), "func.cpp"]
         cr_cmd = " ".join(str(p) for p in cr_params_list)
         cr_ret_code, cr_stdout, cr_stderr, cr_is_time_expired, cr_elapsed_time = \
             common.run_cmd(cr_params_list, creduce_timeout, self.proc_num)
@@ -1351,8 +1352,9 @@ Use specified folder for testing
                              "File comments may start with #")
     parser.add_argument("--blame", dest="blame", default=False, action="store_true",
                         help="Enable optimization triagging for failing tests for supported compilers")
-    parser.add_argument("--creduce", dest="creduce", default=False, action="store_true",
-                        help="Enable test reduction using CReduce tool")
+    parser.add_argument("--creduce", dest="creduce", nargs='?', const=4, type=int, default=False,
+                        help="Enable test reduction using CReduce tool. When given a number, "
+                             "it's used as a number of creduce processes run for a single reduction (default is 4)")
     parser.add_argument("--no-tmp-cleaner", dest="no_tmp_cleaner", default=False, action="store_true",
                         help="Do not run tmp_cleaner.sh script during the run")
     args = parser.parse_args()
@@ -1371,5 +1373,7 @@ Use specified folder for testing
     common.log_msg(logging.DEBUG, "Command line: " + " ".join(str(p) for p in sys.argv))
     common.log_msg(logging.DEBUG, "Start time: " + script_start_time.strftime('%Y/%m/%d %H:%M:%S'))
     common.check_python_version()
+    if args.creduce:
+        creduce_n = args.creduce
     prepare_env_and_start_testing(os.path.abspath(args.out_dir), args.timeout, args.target, args.num_jobs,
                                   args.config_file, args.seeds_option_value, args.blame, args.creduce, args.no_tmp_cleaner)

--- a/run_gen.py
+++ b/run_gen.py
@@ -43,7 +43,7 @@ process_dir = "process_"
 creduce_bin = "creduce"
 
 yarpgen_timeout = 60
-compiler_timeout = 600
+compiler_timeout = 1200
 run_timeout = 300
 stat_update_delay = 10
 tmp_cleanup_delay = 3600
@@ -59,6 +59,11 @@ known_build_fails = { \
     "PromoteIntRes_SETCC" : "Integer type overpromoted", \
     "Cannot_select_urem" : "Cannot select.*urem", \
     "Cannot_select_pcmpeq" : "Cannot select.*X86ISD::PCMPEQ", \
+    "Binary_operator_types_must_match": "Binary operator types must match", \
+    "DAGCombiner_AddToWorklist": "Deleted Node added to Worklist", \
+    "SDNode_getOperand": "Invalid child # of SDNode", \
+    "DELETED_NODE_CSEMap": "DELETED_NODE in CSEMap!", \
+    "VerifyScheduledSequence": "The number of nodes scheduled doesn't match the expected number", \
 # gcc
     "compute_live_loop_exits" : "compute_live_loop_exits", \
     "verify_gimple" : "verify_gimple" \
@@ -283,11 +288,11 @@ class Test(object):
                 bad_runs += run
 
         # Run blame triagging for one of failing optsets
-        if self.blame:
+        if self.blame and good_runs:
             do_blame(self, self.files, good_runs[0].checksum, bad_runs[0].target)
 
         # Run creduce for one of failing optsets
-        if self.creduce:
+        if self.creduce and good_runs:
             self.do_creduce_miscompare(good_runs, bad_runs)
 
         # Report
@@ -411,6 +416,8 @@ class Test(object):
 
         if not good_run:
             # TODO: fix
+            common.log_msg(logging.DEBUG, "No good runs found for seed " + self.seed + \
+                    " in process " + self.proc_num)
             raise
 
         bad_run = None

--- a/run_gen.py
+++ b/run_gen.py
@@ -419,8 +419,8 @@ class Test(object):
 
         if not good_run:
             # TODO: fix
-            common.log_msg(logging.DEBUG, "No good runs found for seed " + self.seed + \
-                    " in process " + self.proc_num)
+            common.log_msg(logging.WARNING, "No good runs found for seed " + self.seed + \
+                    " in process " + self.proc_num, True)
             raise
 
         bad_run = None
@@ -513,8 +513,8 @@ class Test(object):
                 buildfail_run.optset + " with " + (ubsan_run.optset if ubsan_run else "missing ubsan"))
 
         if not ubsan_run:
-            common.log_msg(logging.DEBUG, "Failed to reduce because of missing good ubsan run: seed " + \
-                self.seed)
+            common.log_msg(logging.WARNING, "Failed to reduce because of missing good ubsan run: seed " + \
+                self.seed, True)
             return
 
         # Prepare Makefile

--- a/run_gen.py
+++ b/run_gen.py
@@ -922,7 +922,7 @@ def get_testing_speed(seed_num, time_delta):
     return "{:.2f}".format(seed_num / minutes) + " seed/min"
 
 
-def form_statistics(stat, targets, prev_len):
+def form_statistics(stat, targets, prev_len, tasks = None):
     verbose_stat_str = ""
 
     testing_speed = get_testing_speed(stat.get_yarpgen_runs(total), datetime.datetime.now() - script_start_time)
@@ -985,11 +985,18 @@ def form_statistics(stat, targets, prev_len):
         verbose_stat_str += "FAILED SEEDS (" + str(len(seeds_fail)) + "): " + \
                             ", ".join("S_"+s for s in seeds_fail) + "\n"
 
+    active = 0
+    if tasks:
+        for task in tasks:
+            if task.is_alive():
+                active = active + 1
+
     stat_str = '\r'
     stat_str += "time " + strfdelta(datetime.datetime.now() - script_start_time,
                                     "{days} d {hours}:{minutes}:{seconds}") + " | "
     stat_str += "cpu time: " + strfdelta(total_cpu_duration, "{days} d {hours}:{minutes}:{seconds}") + " | "
     stat_str += testing_speed + " | "
+    stat_str += " active " + str(active) + " | "
     stat_str += "seeds/targets: " + str(total_seeds)+"/"+str(total_runs) + " | "
     stat_str += "Errors(g/ct/c/rt/r/d): " + str(total_gen_errors) + "/"
     stat_str += str(total_compfail_timeout) + "/"
@@ -1012,7 +1019,7 @@ def print_online_statistics_and_cleanup(lock, stat, targets, task_threads, num_j
     start_time = time.time() - tmp_cleanup_delay
     while any_alive:
         lock.acquire()
-        stat_str, verbose_stat_str, prev_len = form_statistics(stat, targets, prev_len)
+        stat_str, verbose_stat_str, prev_len = form_statistics(stat, targets, prev_len, task_threads)
         common.stat_logger.log(logging.INFO, verbose_stat_str)
         sys.stdout.write(stat_str)
         sys.stdout.flush()

--- a/test_sets.txt
+++ b/test_sets.txt
@@ -31,12 +31,14 @@ Compiler specs:
 # Spec name | Executable name | Common arguments                                            | Arch prefix
 gcc         | g++             | -w                                                          | -march=
 clang       | clang++         | -w                                                          | -march=
-# Ubsan it is clang with sanitizer options. It is used for generator check.
-# If you want to use sanitizer with -m32, please make sure that you pass "-rtlib=compiler-rt -lgcc_s" options.
+# Ubsan is clang or gcc with sanitizer options. It is used for generator check.
+# If you want to use sanitizer with -m32, please make sure that you pass "-rtlib=compiler-rt -lgcc_s" options if you are using clang.
 # Otherwise it may fail with "undefined reference to `__mulodi4'" error message.
 # See https://bugs.llvm.org//show_bug.cgi?id=16404 for more information
+# Note that -fpermissive optiuon for gcc is required to allow reduction of ubsan_gcc fails.
+# Otherwise result of reducion is empty program.
 ubsan_clang | clang++         | -fsanitize=undefined -fno-sanitize-recover=undefined -w -Werror=uninitialized | -march=
-ubsan_gcc   | g++             | -fsanitize=undefined -fno-sanitize-recover=undefined -w -Werror=uninitialized | -march=
+ubsan_gcc   | g++             | -fsanitize=undefined -fno-sanitize-recover=undefined -w -Werror=uninitialized -fpermissive | -march=
 icc         | icpc            | -w                                                          | -x
 icx         | icpx            | -w                                                          | -march=
 

--- a/tmp_cleaner.sh
+++ b/tmp_cleaner.sh
@@ -21,6 +21,7 @@ find /tmp -name "check*.cpp" -type f -mmin +60 -delete
 find /tmp -name "driver*.cpp" -type f -mmin +60 -delete
 find /tmp -name "driver*.o" -type f -mmin +60 -delete
 find /tmp -name "func*.cpp" -type f -mmin +60 -delete
+find /tmp -name "func*.sh" -type f -mmin +60 -delete
 find /tmp -name "hash*.cpp" -type f -mmin +60 -delete
 find /tmp -name "init*.cpp" -type f -mmin +60 -delete
 find /tmp -name "init*.sh" -type f -mmin +60 -delete


### PR DESCRIPTION
- runtime fails reduction
- creduce option can now take integral parameter passed to creduce in --n option
- more bugs in bugs.txt
- more known compfail messages for clang and gcc.
- adding info about active tasks in online one-line report
- adding clang after-crash scripts to list of files to cleanup in /tmp