### PR TITLE
Code clean up

### DIFF
--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -40,6 +40,8 @@ std::shared_ptr<Data> Expr::get_value () {
         }
         case Data::VarClassID::MAX_CLASS_ID:
             ERROR("unsupported Data::VarClassID (Expr)");
+        default:
+            ERROR("Expr::get_value() - data corruption");
     }
 }
 
@@ -60,6 +62,8 @@ std::shared_ptr<Expr> VarUseExpr::set_value (std::shared_ptr<Expr> _expr) {
             break;
         case Data::VarClassID::MAX_CLASS_ID:
             ERROR("unsupported Data::VarClassID (VarUseExpr)");
+        default:
+            ERROR("Expr::set_value() - data corruption");
     }
 }
 
@@ -990,6 +994,8 @@ std::shared_ptr<Expr> MemberExpr::set_value (std::shared_ptr<Expr> _expr) {
             break;
         case Data::VarClassID::MAX_CLASS_ID:
             ERROR("unsupported Data::VarClassID (MemberExpr)");
+        default:
+            ERROR("MemberExpr::set_value() - data corruption");
     }
 }
 

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -295,7 +295,7 @@ std::shared_ptr<Expr> ArithExpr::generate (std::shared_ptr<Context> ctx, std::ve
 }
 
 // Top-level recursive function for expression tree generation.
-std::shared_ptr<Expr> ArithExpr::gen_level (std::shared_ptr<Context> ctx, std::vector<std::shared_ptr<Expr>> inp, int par_depth) {
+std::shared_ptr<Expr> ArithExpr::gen_level (std::shared_ptr<Context> ctx, std::vector<std::shared_ptr<Expr>> inp, uint32_t par_depth) {
     auto p = ctx->get_gen_policy();
     //TODO: it is a stub for testing. Rewrite it later.
     // Pick random pattern for single statement and apply it to gen_policy. Update Context with new gen_policy.
@@ -359,7 +359,7 @@ std::shared_ptr<Expr> ArithExpr::gen_level (std::shared_ptr<Context> ctx, std::v
 }
 
 
-std::shared_ptr<UnaryExpr> UnaryExpr::generate (std::shared_ptr<Context> ctx, std::vector<std::shared_ptr<Expr>> inp, int par_depth) {
+std::shared_ptr<UnaryExpr> UnaryExpr::generate (std::shared_ptr<Context> ctx, std::vector<std::shared_ptr<Expr>> inp, uint32_t par_depth) {
     GenPolicy::add_to_complexity(Node::NodeID::UNARY);
     UnaryExpr::Op op_type = rand_val_gen->get_rand_id(ctx->get_gen_policy()->get_allowed_unary_op());
     std::shared_ptr<Expr> rhs = ArithExpr::gen_level (ctx, inp, par_depth);
@@ -525,7 +525,7 @@ std::string UnaryExpr::emit (std::string offset) {
     return ret;
 }
 
-std::shared_ptr<BinaryExpr> BinaryExpr::generate (std::shared_ptr<Context> ctx, std::vector<std::shared_ptr<Expr>> inp, int par_depth) {
+std::shared_ptr<BinaryExpr> BinaryExpr::generate (std::shared_ptr<Context> ctx, std::vector<std::shared_ptr<Expr>> inp, uint32_t par_depth) {
     GenPolicy::add_to_complexity(Node::NodeID::BINARY);
     BinaryExpr::Op op_type = rand_val_gen->get_rand_id(ctx->get_gen_policy()->get_allowed_binary_op());
     std::shared_ptr<Expr> lhs = ArithExpr::gen_level (ctx, inp, par_depth);

--- a/src/expr.h
+++ b/src/expr.h
@@ -139,7 +139,7 @@ class ArithExpr : public Expr {
         // Bridge to choose_and_apply_ssp_const_use and choose_and_apply_ssp_similar_op. This function combines both of them.
         static GenPolicy choose_and_apply_ssp (GenPolicy old_gen_policy);
         // Top-level recursive function for expression tree generation
-        static std::shared_ptr<Expr> gen_level (std::shared_ptr<Context> ctx, std::vector<std::shared_ptr<Expr>> inp, int par_depth);
+        static std::shared_ptr<Expr> gen_level (std::shared_ptr<Context> ctx, std::vector<std::shared_ptr<Expr>> inp, uint32_t par_depth);
 
         std::shared_ptr<Expr> integral_prom (std::shared_ptr<Expr> arg);
         std::shared_ptr<Expr> conv_to_bool (std::shared_ptr<Expr> arg);
@@ -163,7 +163,7 @@ class UnaryExpr : public ArithExpr {
         UnaryExpr (Op _op, std::shared_ptr<Expr> _arg);
         Op get_op () { return op; }
         std::string emit (std::string offset = "");
-        static std::shared_ptr<UnaryExpr> generate (std::shared_ptr<Context> ctx, std::vector<std::shared_ptr<Expr>> inp, int par_depth);
+        static std::shared_ptr<UnaryExpr> generate (std::shared_ptr<Context> ctx, std::vector<std::shared_ptr<Expr>> inp, uint32_t par_depth);
 
     private:
         bool propagate_type ();
@@ -208,7 +208,7 @@ class BinaryExpr : public ArithExpr {
         BinaryExpr (Op _op, std::shared_ptr<Expr> lhs, std::shared_ptr<Expr> rhs);
         Op get_op () { return op; }
         std::string emit (std::string offset = "");
-        static std::shared_ptr<BinaryExpr> generate (std::shared_ptr<Context> ctx, std::vector<std::shared_ptr<Expr>> inp, int par_depth);
+        static std::shared_ptr<BinaryExpr> generate (std::shared_ptr<Context> ctx, std::vector<std::shared_ptr<Expr>> inp, uint32_t par_depth);
 
     private:
         bool propagate_type ();

--- a/src/expr.h
+++ b/src/expr.h
@@ -20,9 +20,9 @@ limitations under the License.
 
 #include <vector>
 
+#include "ir_node.h"
 #include "type.h"
 #include "variable.h"
-#include "ir_node.h"
 
 namespace yarpgen {
 

--- a/src/gen_policy.cpp
+++ b/src/gen_policy.cpp
@@ -321,7 +321,7 @@ GenPolicy GenPolicy::apply_arith_ssp_similar_op (ArithSSP::SimilarOp pattern_id)
 void GenPolicy::rand_init_allowed_int_types () {
     allowed_int_types.clear ();
     std::vector<IntegerType::IntegerTypeID> tmp_allowed_int_types;
-    int gen_types = 0;
+    uint32_t gen_types = 0;
     while (gen_types < num_of_allowed_int_types) {
         IntegerType::IntegerTypeID type = (IntegerType::IntegerTypeID) rand_val_gen->get_rand_value<int>(0, IntegerType::IntegerTypeID::MAX_INT_ID - 1);
         if (type == IntegerType::IntegerTypeID::BOOL && options->is_c())

--- a/src/gen_policy.cpp
+++ b/src/gen_policy.cpp
@@ -23,46 +23,46 @@ limitations under the License.
 
 using namespace yarpgen;
 
-const int MAX_ALLOWED_INT_TYPES = 3;
+const uint32_t MAX_ALLOWED_INT_TYPES = 3;
 
-const int MAX_ARITH_DEPTH = 5;
+const uint32_t MAX_ARITH_DEPTH = 5;
 
-const int MIN_SCOPE_STMT_COUNT = 5;
-const int MAX_SCOPE_STMT_COUNT = 10;
+const uint32_t MIN_SCOPE_STMT_COUNT = 5;
+const uint32_t MAX_SCOPE_STMT_COUNT = 10;
 
-const int MAX_TOTAL_STMT_COUNT = 5000;
+const uint32_t MAX_TOTAL_STMT_COUNT = 5000;
 
-const int MIN_INP_VAR_COUNT = 20;
-const int MAX_INP_VAR_COUNT = 60;
-const int MIN_MIX_VAR_COUNT = 20;
-const int MAX_MIX_VAR_COUNT = 60;
+const uint32_t MIN_INP_VAR_COUNT = 20;
+const uint32_t MAX_INP_VAR_COUNT = 60;
+const uint32_t MIN_MIX_VAR_COUNT = 20;
+const uint32_t MAX_MIX_VAR_COUNT = 60;
 
-const int MAX_CSE_COUNT = 5;
+const uint32_t MAX_CSE_COUNT = 5;
 
-const int MAX_IF_DEPTH = 3;
+const uint32_t MAX_IF_DEPTH = 3;
 
 const uint64_t MAX_TEST_COMPLEXITY = UINT64_MAX;
 
-const int MIN_STRUCT_TYPES_COUNT = 0;
-const int MAX_STRUCT_TYPES_COUNT = 6;
-const int MIN_INP_STRUCT_COUNT = 0;
-const int MAX_INP_STRUCT_COUNT = 6;
-const int MIN_MIX_STRUCT_COUNT = 0;
-const int MAX_MIX_STRUCT_COUNT = 6;
-const int MIN_OUT_STRUCT_COUNT = 0;
-const int MAX_OUT_STRUCT_COUNT = 8;
-const int MIN_STRUCT_MEMBER_COUNT = 1;
-const int MAX_STRUCT_MEMBER_COUNT = 10;
-const int MAX_STRUCT_DEPTH = 5;
-const int MIN_BIT_FIELD_SIZE = 8;
-const int MAX_BIT_FIELD_SIZE = 2; //TODO: unused, because it cause different result for LLVM and GCC. See pr70733
+const uint32_t MIN_STRUCT_TYPES_COUNT = 0;
+const uint32_t MAX_STRUCT_TYPES_COUNT = 6;
+const uint32_t MIN_INP_STRUCT_COUNT = 0;
+const uint32_t MAX_INP_STRUCT_COUNT = 6;
+const uint32_t MIN_MIX_STRUCT_COUNT = 0;
+const uint32_t MAX_MIX_STRUCT_COUNT = 6;
+const uint32_t MIN_OUT_STRUCT_COUNT = 0;
+const uint32_t MAX_OUT_STRUCT_COUNT = 8;
+const uint32_t MIN_STRUCT_MEMBER_COUNT = 1;
+const uint32_t MAX_STRUCT_MEMBER_COUNT = 10;
+const uint32_t MAX_STRUCT_DEPTH = 5;
+const uint32_t MIN_BIT_FIELD_SIZE = 8;
+const uint32_t MAX_BIT_FIELD_SIZE = 2; //TODO: unused, because it cause different result for LLVM and GCC. See pr70733
 
 ///////////////////////////////////////////////////////////////////////////////
 
 std::shared_ptr<RandValGen> yarpgen::rand_val_gen;
-uint64_t RandValGen::struct_type_count = 0;
-uint64_t RandValGen::scalar_var_count = 0;
-uint64_t RandValGen::struct_var_count = 0;
+uint32_t RandValGen::struct_type_count = 0;
+uint32_t RandValGen::scalar_var_count = 0;
+uint32_t RandValGen::struct_var_count = 0;
 
 RandValGen::RandValGen (uint64_t _seed) {
     if (_seed != 0) {

--- a/src/gen_policy.h
+++ b/src/gen_policy.h
@@ -17,10 +17,10 @@ limitations under the License.
 //////////////////////////////////////////////////////////////////////////////
 #pragma once
 
-#include <random>
 #include <algorithm>
 #include <iostream>
 #include <memory>
+#include <random>
 
 #include "type.h"
 #include "variable.h"

--- a/src/gen_policy.h
+++ b/src/gen_policy.h
@@ -38,7 +38,7 @@ namespace yarpgen {
 template<typename T>
 class Probability {
     public:
-        Probability (T _id, int _prob) : id(_id), prob (_prob) {}
+        Probability (T _id, uint64_t _prob) : id(_id), prob (_prob) {}
         T get_id () { return id; }
         uint64_t get_prob () { return prob; }
         void increase_prob(uint64_t add_prob) { prob += add_prob; }
@@ -75,7 +75,7 @@ class RandValGen {
         }
 
         std::string get_struct_type_name() { return "struct_" + std::to_string(++struct_type_count); }
-        uint64_t    get_struct_type_count() { return struct_type_count; }
+        uint32_t    get_struct_type_count() { return struct_type_count; }
         std::string get_scalar_var_name() { return "var_" + std::to_string(++scalar_var_count); }
         std::string get_struct_var_name() { return "struct_obj_" + std::to_string(++struct_var_count); }
 
@@ -106,9 +106,9 @@ class RandValGen {
     private:
         uint64_t seed;
         std::mt19937_64 rand_gen;
-        static uint64_t struct_type_count;
-        static uint64_t scalar_var_count;
-        static uint64_t struct_var_count;
+        static uint32_t struct_type_count;
+        static uint32_t scalar_var_count;
+        static uint32_t struct_var_count;
 };
 
 extern std::shared_ptr<RandValGen> rand_val_gen;
@@ -189,8 +189,8 @@ class GenPolicy {
 
         // Integer types section - defines number and type (bool, char ...) of available integer types
         void rand_init_allowed_int_types ();
-        void set_num_of_allowed_int_types (int _num_of_allowed_int_types) { num_of_allowed_int_types = _num_of_allowed_int_types; }
-        int get_num_of_allowed_int_types () { return num_of_allowed_int_types; }
+        void set_num_of_allowed_int_types (uint32_t _num_of_allowed_int_types) { num_of_allowed_int_types = _num_of_allowed_int_types; }
+        uint32_t get_num_of_allowed_int_types () { return num_of_allowed_int_types; }
         std::vector<Probability<IntegerType::IntegerTypeID>>& get_allowed_int_types () { return allowed_int_types; }
         void add_allowed_int_type (Probability<IntegerType::IntegerTypeID> allowed_int_type) { allowed_int_types.push_back(allowed_int_type); }
 
@@ -214,15 +214,15 @@ class GenPolicy {
         // distribution of bit fields properties ...
         void set_allow_struct (bool _allow_struct) { allow_struct = _allow_struct; }
         bool get_allow_struct () { return allow_struct; }
-        void set_min_struct_type_count (uint64_t _min_struct_type_count) { min_struct_type_count = _min_struct_type_count; }
-        uint64_t get_min_struct_type_count () { return min_struct_type_count; }
-        void set_max_struct_type_count (uint64_t _max_struct_type_count) { max_struct_type_count = _max_struct_type_count; }
-        uint64_t get_max_struct_type_count () { return max_struct_type_count; }
-        void set_min_inp_struct_count (uint64_t _min_inp_struct_count) { min_inp_struct_count = _min_inp_struct_count; }
-        void set_min_struct_member_count (uint64_t _min_struct_member_count) { min_struct_member_count = _min_struct_member_count; }
-        uint64_t get_min_struct_member_count () { return min_struct_member_count; }
-        void set_max_struct_member_count (uint64_t _max_struct_member_count) { max_struct_member_count = _max_struct_member_count; }
-        uint64_t get_max_struct_member_count () { return max_struct_member_count; }
+        void set_min_struct_type_count (uint32_t _min_struct_type_count) { min_struct_type_count = _min_struct_type_count; }
+        uint32_t get_min_struct_type_count () { return min_struct_type_count; }
+        void set_max_struct_type_count (uint32_t _max_struct_type_count) { max_struct_type_count = _max_struct_type_count; }
+        uint32_t get_max_struct_type_count () { return max_struct_type_count; }
+        void set_min_inp_struct_count (uint32_t _min_inp_struct_count) { min_inp_struct_count = _min_inp_struct_count; }
+        void set_min_struct_member_count (uint32_t _min_struct_member_count) { min_struct_member_count = _min_struct_member_count; }
+        uint32_t get_min_struct_member_count () { return min_struct_member_count; }
+        void set_max_struct_member_count (uint32_t _max_struct_member_count) { max_struct_member_count = _max_struct_member_count; }
+        uint32_t get_max_struct_member_count () { return max_struct_member_count; }
         void set_allow_mix_cv_qual_in_struct(bool mix) { allow_mix_cv_qual_in_struct = mix; }
         bool get_allow_mix_cv_qual_in_struct() { return allow_mix_cv_qual_in_struct; }
         void set_allow_static_members (bool _allow_static_members) { allow_static_members = _allow_static_members; }
@@ -232,43 +232,43 @@ class GenPolicy {
         void set_allow_mix_types_in_struct (bool mix) { allow_mix_types_in_struct = mix; }
         bool get_allow_mix_types_in_struct () { return allow_mix_types_in_struct; }
         std::vector<Probability<bool>> get_member_use_prob () { return member_use_prob; }
-        void set_max_struct_depth (uint64_t _max_struct_depth) { max_struct_depth = _max_struct_depth; }
-        uint64_t get_max_struct_depth () { return max_struct_depth; }
+        void set_max_struct_depth (uint32_t _max_struct_depth) { max_struct_depth = _max_struct_depth; }
+        uint32_t get_max_struct_depth () { return max_struct_depth; }
         std::vector<Probability<Data::VarClassID>>& get_member_class_prob () { return member_class_prob; }
         void add_out_data_type_prob(Probability<OutDataTypeID> prob) { out_data_type_prob.push_back(prob); }
-        void set_min_bit_field_size (uint64_t _min_bit_field_size) { min_bit_field_size = _min_bit_field_size; }
-        uint64_t get_min_bit_field_size () { return min_bit_field_size; }
-        void set_max_bit_field_size (uint64_t _max_bit_field_size) { max_bit_field_size = _max_bit_field_size; }
-        uint64_t get_max_bit_field_size () { return max_bit_field_size; }
+        void set_min_bit_field_size (uint32_t _min_bit_field_size) { min_bit_field_size = _min_bit_field_size; }
+        uint32_t get_min_bit_field_size () { return min_bit_field_size; }
+        void set_max_bit_field_size (uint32_t _max_bit_field_size) { max_bit_field_size = _max_bit_field_size; }
+        uint32_t get_max_bit_field_size () { return max_bit_field_size; }
         std::vector<Probability<BitFieldID>>& get_bit_field_prob () { return bit_field_prob; }
         void add_bit_field_prob(Probability<BitFieldID> prob) { bit_field_prob.push_back(prob); }
 
         // Variables section - defines total number of variables of each kind (input and mix),
         // distribution of type of output variables.
-        void set_min_inp_var_count (int _min_inp_var_count) { min_inp_var_count = _min_inp_var_count; }
-        int get_min_inp_var_count () { return min_inp_var_count; }
-        void set_max_inp_var_count (int _max_inp_var_count) { max_inp_var_count = _max_inp_var_count; }
-        int get_max_inp_var_count () { return max_inp_var_count; }
-        void set_min_mix_var_count (int _min_mix_var_count) { min_mix_var_count = _min_mix_var_count; }
-        int get_min_mix_var_count () { return min_mix_var_count; }
-        void set_max_mix_var_count (int _max_mix_var_count) { max_mix_var_count = _max_mix_var_count; }
-        int get_max_mix_var_count () { return max_mix_var_count; }
+        void set_min_inp_var_count (uint32_t _min_inp_var_count) { min_inp_var_count = _min_inp_var_count; }
+        uint32_t get_min_inp_var_count () { return min_inp_var_count; }
+        void set_max_inp_var_count (uint32_t _max_inp_var_count) { max_inp_var_count = _max_inp_var_count; }
+        uint32_t get_max_inp_var_count () { return max_inp_var_count; }
+        void set_min_mix_var_count (uint32_t _min_mix_var_count) { min_mix_var_count = _min_mix_var_count; }
+        uint32_t get_min_mix_var_count () { return min_mix_var_count; }
+        void set_max_mix_var_count (uint32_t _max_mix_var_count) { max_mix_var_count = _max_mix_var_count; }
+        uint32_t get_max_mix_var_count () { return max_mix_var_count; }
         std::vector<Probability<OutDataTypeID>> get_out_data_type_prob() { return out_data_type_prob; }
-        uint64_t get_min_inp_struct_count () { return min_inp_struct_count; }
-        void set_max_inp_struct_count (uint64_t _max_inp_struct_count) { max_inp_struct_count = _max_inp_struct_count; }
-        uint64_t get_max_inp_struct_count () { return max_inp_struct_count; }
-        void set_min_mix_struct_count (uint64_t _min_mix_struct_count) { min_mix_struct_count = _min_mix_struct_count; }
-        uint64_t get_min_mix_struct_count () { return min_mix_struct_count; }
-        void set_max_mix_struct_count (uint64_t _max_mix_struct_count) { max_mix_struct_count = _max_mix_struct_count; }
-        uint64_t get_max_mix_struct_count () { return max_mix_struct_count; }
-        void set_min_out_struct_count (uint64_t _min_out_struct_count) { min_out_struct_count = _min_out_struct_count; }
-        uint64_t get_min_out_struct_count () { return min_out_struct_count; }
-        void set_max_out_struct_count (uint64_t _max_out_struct_count) { max_out_struct_count = _max_out_struct_count; }
-        uint64_t get_max_out_struct_count () { return max_out_struct_count; }
+        uint32_t get_min_inp_struct_count () { return min_inp_struct_count; }
+        void set_max_inp_struct_count (uint32_t _max_inp_struct_count) { max_inp_struct_count = _max_inp_struct_count; }
+        uint32_t get_max_inp_struct_count () { return max_inp_struct_count; }
+        void set_min_mix_struct_count (uint32_t _min_mix_struct_count) { min_mix_struct_count = _min_mix_struct_count; }
+        uint32_t get_min_mix_struct_count () { return min_mix_struct_count; }
+        void set_max_mix_struct_count (uint32_t _max_mix_struct_count) { max_mix_struct_count = _max_mix_struct_count; }
+        uint32_t get_max_mix_struct_count () { return max_mix_struct_count; }
+        void set_min_out_struct_count (uint32_t _min_out_struct_count) { min_out_struct_count = _min_out_struct_count; }
+        uint32_t get_min_out_struct_count () { return min_out_struct_count; }
+        void set_max_out_struct_count (uint32_t _max_out_struct_count) { max_out_struct_count = _max_out_struct_count; }
+        uint32_t get_max_out_struct_count () { return max_out_struct_count; }
 
         // Arithmetic expression tree section - defines depth, operators distribution, kind of leaves
-        void set_max_arith_depth (int _max_arith_depth) { max_arith_depth = _max_arith_depth; }
-        int get_max_arith_depth () { return max_arith_depth; }
+        void set_max_arith_depth (uint32_t _max_arith_depth) { max_arith_depth = _max_arith_depth; }
+        uint32_t get_max_arith_depth () { return max_arith_depth; }
         void add_unary_op (Probability<UnaryExpr::Op> prob) { allowed_unary_op.push_back(prob); }
         std::vector<Probability<UnaryExpr::Op>>& get_allowed_unary_op () { return allowed_unary_op; }
         void add_binary_op (Probability<BinaryExpr::Op> prob) { allowed_binary_op.push_back(prob); }
@@ -277,8 +277,8 @@ class GenPolicy {
         std::vector<Probability<ArithDataID>>& get_arith_data_distr () { return arith_data_distr; }
 
         // CSE section
-        void set_max_cse_count (int _max_cse_count) { max_cse_count = _max_cse_count; }
-        int get_max_cse_count () { return max_cse_count; }
+        void set_max_cse_count (uint32_t _max_cse_count) { max_cse_count = _max_cse_count; }
+        uint32_t get_max_cse_count () { return max_cse_count; }
         // TODO: add depth control
         std::vector<std::shared_ptr<Expr>>& get_cse () { return cse; };
         void add_cse (std::shared_ptr<Expr> expr) { cse.push_back(expr); }
@@ -294,15 +294,15 @@ class GenPolicy {
 
         // Statement section - defines their number (per scope and total), distribution and properties
         std::vector<Probability<Node::NodeID>>& get_stmt_gen_prob () { return stmt_gen_prob; }
-        void set_min_scope_stmt_count (int _min_scope_stmt_count) { min_scope_stmt_count = _min_scope_stmt_count; }
-        int get_min_scope_stmt_count () { return min_scope_stmt_count; }
-        void set_max_scope_stmt_count (int _max_scope_stmt_count) { max_scope_stmt_count = _max_scope_stmt_count; }
-        int get_max_scope_stmt_count () { return max_scope_stmt_count; }
-        void set_max_total_stmt_count (int _max_total_stmt_count) { max_total_stmt_count = _max_total_stmt_count; }
-        int get_max_total_stmt_count () { return max_total_stmt_count; }
+        void set_min_scope_stmt_count (uint32_t _min_scope_stmt_count) { min_scope_stmt_count = _min_scope_stmt_count; }
+        uint32_t get_min_scope_stmt_count () { return min_scope_stmt_count; }
+        void set_max_scope_stmt_count (uint32_t _max_scope_stmt_count) { max_scope_stmt_count = _max_scope_stmt_count; }
+        uint32_t get_max_scope_stmt_count () { return max_scope_stmt_count; }
+        void set_max_total_stmt_count (uint32_t _max_total_stmt_count) { max_total_stmt_count = _max_total_stmt_count; }
+        uint32_t get_max_total_stmt_count () { return max_total_stmt_count; }
         std::vector<Probability<bool>>& get_else_prob () { return else_prob; }
-        void set_max_if_depth (int _max_if_depth) { max_if_depth = _max_if_depth; }
-        int get_max_if_depth () { return max_if_depth; }
+        void set_max_if_depth (uint32_t _max_if_depth) { max_if_depth = _max_if_depth; }
+        uint32_t get_max_if_depth () { return max_if_depth; }
 
         ///////////////////////////////////////////////////////////////////////
 
@@ -314,7 +314,7 @@ class GenPolicy {
         uint64_t max_test_complexity;
 
         // Types
-        int num_of_allowed_int_types;
+        uint32_t num_of_allowed_int_types;
         std::vector<Probability<IntegerType::IntegerTypeID>> allowed_int_types;
 
         // cv-qualifiers
@@ -327,43 +327,43 @@ class GenPolicy {
 
         // Struct
         bool allow_struct;
-        uint64_t min_struct_type_count;
-        uint64_t max_struct_type_count;
-        uint64_t min_struct_member_count;
-        uint64_t max_struct_member_count;
+        uint32_t min_struct_type_count;
+        uint32_t max_struct_type_count;
+        uint32_t min_struct_member_count;
+        uint32_t max_struct_member_count;
         bool allow_mix_cv_qual_in_struct;
         bool allow_mix_static_in_struct;
         bool allow_mix_types_in_struct;
         bool allow_static_members;
         std::vector<Probability<bool>> member_use_prob;
         std::vector<Probability<Data::VarClassID>> member_class_prob;
-        uint64_t max_struct_depth;
+        uint32_t max_struct_depth;
         std::vector<Probability<OutDataTypeID>> out_data_type_prob;
-        uint64_t min_bit_field_size;
-        uint64_t max_bit_field_size;
+        uint32_t min_bit_field_size;
+        uint32_t max_bit_field_size;
         std::vector<Probability<BitFieldID>> bit_field_prob;
 
         // Variable
-        int min_inp_var_count;
-        int max_inp_var_count;
-        int min_mix_var_count;
-        int max_mix_var_count;
-        uint64_t min_inp_struct_count;
-        uint64_t max_inp_struct_count;
-        uint64_t min_mix_struct_count;
-        uint64_t max_mix_struct_count;
-        uint64_t min_out_struct_count;
-        uint64_t max_out_struct_count;
+        uint32_t min_inp_var_count;
+        uint32_t max_inp_var_count;
+        uint32_t min_mix_var_count;
+        uint32_t max_mix_var_count;
+        uint32_t min_inp_struct_count;
+        uint32_t max_inp_struct_count;
+        uint32_t min_mix_struct_count;
+        uint32_t max_mix_struct_count;
+        uint32_t min_out_struct_count;
+        uint32_t max_out_struct_count;
 
         // Arithmetic expression tree
-        int max_arith_depth;
+        uint32_t max_arith_depth;
         std::vector<Probability<UnaryExpr::Op>> allowed_unary_op;
         std::vector<Probability<BinaryExpr::Op>> allowed_binary_op;
         std::vector<Probability<ArithLeafID>> arith_leaves;
         std::vector<Probability<ArithDataID>> arith_data_distr;
 
         // CSE
-        int max_cse_count;
+        uint32_t max_cse_count;
         std::vector<Probability<ArithCSEGenID>> arith_cse_gen;
         std::vector<std::shared_ptr<Expr>> cse;
 
@@ -374,12 +374,12 @@ class GenPolicy {
         ArithSSP::SimilarOp chosen_arith_ssp_similar_op;
 
         // Statements
-        int min_scope_stmt_count;
-        int max_scope_stmt_count;
-        int max_total_stmt_count;
+        uint32_t min_scope_stmt_count;
+        uint32_t max_scope_stmt_count;
+        uint32_t max_total_stmt_count;
         std::vector<Probability<Node::NodeID>> stmt_gen_prob;
         std::vector<Probability<bool>> else_prob;
-        int max_if_depth;
+        uint32_t max_if_depth;
 };
 
 extern GenPolicy default_gen_policy;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,11 +16,12 @@ limitations under the License.
 
 //////////////////////////////////////////////////////////////////////////////
 
-#include <cstdint>
-#include <iostream>
-#include <cstring>
-#include <cstdlib>
 #include <cassert>
+#include <cstring>
+#include <cstdint>
+#include <cstdlib>
+#include <functional>
+#include <iostream>
 
 #include "gen_policy.h"
 #include "master.h"

--- a/src/options.h
+++ b/src/options.h
@@ -19,6 +19,7 @@ limitations under the License.
 #pragma once
 
 #include <map>
+#include <string>
 
 namespace yarpgen {
 

--- a/src/stmt.cpp
+++ b/src/stmt.cpp
@@ -109,7 +109,7 @@ std::shared_ptr<ScopeStmt> ScopeStmt::generate (std::shared_ptr<Context> ctx) {
     //TODO: add to gen_policy stmt number
     auto p = ctx->get_gen_policy();
     int scope_stmt_count = rand_val_gen->get_rand_value<int>(p->get_min_scope_stmt_count(), p->get_max_scope_stmt_count());
-    for (int i = 0; i < scope_stmt_count; ++i) {
+    for (uint32_t i = 0; i < scope_stmt_count; ++i) {
         if (total_stmt_count >= p->get_max_total_stmt_count())
             //TODO: Can we somehow eliminate compiler timeout with the help of this?
             //GenPolicy::get_test_complexity() >= p->get_max_test_complexity())

--- a/src/stmt.cpp
+++ b/src/stmt.cpp
@@ -22,7 +22,7 @@ limitations under the License.
 
 using namespace yarpgen;
 
-int Stmt::total_stmt_count = 0;
+uint32_t Stmt::total_stmt_count = 0;
 
 DeclStmt::DeclStmt (std::shared_ptr<Data> _data, std::shared_ptr<Expr> _init, bool _is_extern) :
                   Stmt(Node::NodeID::DECL), data(_data), init(_init), is_extern(_is_extern) {
@@ -108,7 +108,7 @@ std::shared_ptr<ScopeStmt> ScopeStmt::generate (std::shared_ptr<Context> ctx) {
 
     //TODO: add to gen_policy stmt number
     auto p = ctx->get_gen_policy();
-    int scope_stmt_count = rand_val_gen->get_rand_value<int>(p->get_min_scope_stmt_count(), p->get_max_scope_stmt_count());
+    uint32_t scope_stmt_count = rand_val_gen->get_rand_value<uint32_t>(p->get_min_scope_stmt_count(), p->get_max_scope_stmt_count());
     for (uint32_t i = 0; i < scope_stmt_count; ++i) {
         if (total_stmt_count >= p->get_max_total_stmt_count())
             //TODO: Can we somehow eliminate compiler timeout with the help of this?
@@ -130,18 +130,18 @@ std::shared_ptr<ScopeStmt> ScopeStmt::generate (std::shared_ptr<Context> ctx) {
         if (gen_id == Node::NodeID::EXPR) {
             //TODO: add to gen_policy
             // Are we going to use mixed variable or create new outpu variable?
-            bool use_mix = rand_val_gen->get_rand_value<int>(0, 1);
+            bool use_mix = rand_val_gen->get_rand_value<uint32_t>(0, 1);
             GenPolicy::OutDataTypeID out_data_type = rand_val_gen->get_rand_id(p->get_out_data_type_prob());
             std::shared_ptr<Expr> assign_lhs = nullptr;
             if (use_mix) {
                 // Use mixed variable or we don't have any suitable members
                 if (out_data_type == GenPolicy::OutDataTypeID::VAR || ctx->get_extern_mix_sym_table()->get_avail_members().size() == 0) {
-                    int mix_num = rand_val_gen->get_rand_value<int>(0, ctx->get_extern_mix_sym_table()->get_variables().size() - 1);
+                    uint32_t mix_num = rand_val_gen->get_rand_value<uint32_t>(0, ctx->get_extern_mix_sym_table()->get_variables().size() - 1);
                     assign_lhs = std::make_shared<VarUseExpr>(ctx->get_extern_mix_sym_table()->get_variables().at(mix_num));
                 }
                 // Use member of mixed struct
                 else {
-                    int mix_num = rand_val_gen->get_rand_value<int>(0, ctx->get_extern_mix_sym_table()->get_avail_members().size() - 1);
+                    uint32_t mix_num = rand_val_gen->get_rand_value<uint32_t>(0, ctx->get_extern_mix_sym_table()->get_avail_members().size() - 1);
                     assign_lhs = ctx->get_extern_mix_sym_table()->get_avail_members().at(mix_num);
                 }
             }
@@ -154,7 +154,7 @@ std::shared_ptr<ScopeStmt> ScopeStmt::generate (std::shared_ptr<Context> ctx) {
                 }
                 // Use member of output struct
                 else {
-                    int out_num = rand_val_gen->get_rand_value<int>(0, ctx->get_extern_out_sym_table()->get_avail_members().size() - 1);
+                    uint32_t out_num = rand_val_gen->get_rand_value<uint32_t>(0, ctx->get_extern_out_sym_table()->get_avail_members().size() - 1);
                     assign_lhs = ctx->get_extern_out_sym_table()->get_avail_members().at(out_num);
                     ctx->get_extern_out_sym_table()->del_avail_member(out_num);
                 }
@@ -220,23 +220,23 @@ void ScopeStmt::form_extern_sym_table(std::shared_ptr<Context> ctx) {
     const_gen_policy.set_allow_const(true);
     const_ctx->set_gen_policy(const_gen_policy);
     // Generate random number of random input variables
-    int inp_var_count = rand_val_gen->get_rand_value<int>(p->get_min_inp_var_count(), p->get_max_inp_var_count());
-    for (int i = 0; i < inp_var_count; ++i) {
+    uint32_t inp_var_count = rand_val_gen->get_rand_value<uint32_t>(p->get_min_inp_var_count(), p->get_max_inp_var_count());
+    for (uint32_t i = 0; i < inp_var_count; ++i) {
         ctx->get_extern_inp_sym_table()->add_variable(ScalarVariable::generate(const_ctx));
     }
     //TODO: add to gen_policy
     // Same for mixed variables
-    int mix_var_count = rand_val_gen->get_rand_value<int>(p->get_min_mix_var_count(), p->get_max_mix_var_count());
-    for (int i = 0; i < mix_var_count; ++i) {
+    uint32_t mix_var_count = rand_val_gen->get_rand_value<uint32_t>(p->get_min_mix_var_count(), p->get_max_mix_var_count());
+    for (uint32_t i = 0; i < mix_var_count; ++i) {
         ctx->get_extern_mix_sym_table()->add_variable(ScalarVariable::generate(ctx));
     }
 
-    int struct_type_count = rand_val_gen->get_rand_value<int>(p->get_min_struct_type_count(), p->get_max_struct_type_count());
+    uint32_t struct_type_count = rand_val_gen->get_rand_value<uint32_t>(p->get_min_struct_type_count(), p->get_max_struct_type_count());
     if (struct_type_count == 0)
         return;
 
     // Create random number of struct definition
-    for (int i = 0; i < struct_type_count; ++i) {
+    for (uint32_t i = 0; i < struct_type_count; ++i) {
         //TODO: Maybe we should create one container for all struct types? And should they all be equal?
         std::shared_ptr<StructType> struct_type = StructType::generate(ctx, ctx->get_extern_inp_sym_table()->get_struct_types());
         ctx->get_extern_inp_sym_table()->add_struct_type(struct_type);
@@ -245,21 +245,21 @@ void ScopeStmt::form_extern_sym_table(std::shared_ptr<Context> ctx) {
     }
 
     // Create random number of input structures
-    int inp_struct_count = rand_val_gen->get_rand_value<int>(p->get_min_inp_struct_count(), p->get_max_inp_struct_count());
-    for (int i = 0; i < inp_struct_count; ++i) {
-        int struct_type_indx = rand_val_gen->get_rand_value<int>(0, struct_type_count - 1);
+    uint32_t inp_struct_count = rand_val_gen->get_rand_value<uint32_t>(p->get_min_inp_struct_count(), p->get_max_inp_struct_count());
+    for (uint32_t i = 0; i < inp_struct_count; ++i) {
+        uint32_t struct_type_indx = rand_val_gen->get_rand_value<uint32_t>(0, struct_type_count - 1);
         ctx->get_extern_inp_sym_table()->add_struct(Struct::generate(const_ctx, ctx->get_extern_inp_sym_table()->get_struct_types().at(struct_type_indx)));
     }
     // Same for mixed structures
-    int mix_struct_count = rand_val_gen->get_rand_value<int>(p->get_min_mix_struct_count(), p->get_max_mix_struct_count());
-    for (int i = 0; i < mix_struct_count; ++i) {
-        int struct_type_indx = rand_val_gen->get_rand_value<int>(0, struct_type_count - 1);
+    uint32_t mix_struct_count = rand_val_gen->get_rand_value<uint32_t>(p->get_min_mix_struct_count(), p->get_max_mix_struct_count());
+    for (uint32_t i = 0; i < mix_struct_count; ++i) {
+        uint32_t struct_type_indx = rand_val_gen->get_rand_value<uint32_t>(0, struct_type_count - 1);
         ctx->get_extern_mix_sym_table()->add_struct(Struct::generate(ctx, ctx->get_extern_mix_sym_table()->get_struct_types().at(struct_type_indx)));
     }
     // Same for output structures
-    int out_struct_count = rand_val_gen->get_rand_value<int>(p->get_min_out_struct_count(), p->get_max_out_struct_count());
-    for (int i = 0; i < out_struct_count; ++i) {
-        int struct_type_indx = rand_val_gen->get_rand_value<int>(0, struct_type_count - 1);
+    uint32_t out_struct_count = rand_val_gen->get_rand_value<uint32_t>(p->get_min_out_struct_count(), p->get_max_out_struct_count());
+    for (uint32_t i = 0; i < out_struct_count; ++i) {
+        uint32_t struct_type_indx = rand_val_gen->get_rand_value<uint32_t>(0, struct_type_count - 1);
         ctx->get_extern_out_sym_table()->add_struct(Struct::generate(ctx, ctx->get_extern_out_sym_table()->get_struct_types().at(struct_type_indx)));
     }
 }

--- a/src/stmt.h
+++ b/src/stmt.h
@@ -35,7 +35,7 @@ class Stmt : public Node {
         Stmt (Node::NodeID _id) : Node(_id) {};
 
     protected:
-        static int total_stmt_count;
+        static uint32_t total_stmt_count;
 };
 
 // Declaration statement creates new variable (declares variable in current context) and adds it to local symbol table:

--- a/src/sym_table.cpp
+++ b/src/sym_table.cpp
@@ -29,7 +29,7 @@ void SymbolTable::add_struct (std::shared_ptr<Struct> _struct) {
 }
 
 void SymbolTable::form_struct_member_expr (std::shared_ptr<MemberExpr> parent_memb_expr, std::shared_ptr<Struct> struct_var, bool ignore_const) {
-    for (int j = 0; j < struct_var->get_member_count(); ++j) {
+    for (uint32_t j = 0; j < struct_var->get_member_count(); ++j) {
         GenPolicy gen_policy;
         if (rand_val_gen->get_rand_id(gen_policy.get_member_use_prob())) {
             std::shared_ptr<MemberExpr> member_expr;
@@ -117,7 +117,7 @@ std::string SymbolTable::emit_struct_init (std::string offset) {
 
 std::string SymbolTable::emit_single_struct_init (std::shared_ptr<MemberExpr> parent_memb_expr, std::shared_ptr<Struct> struct_var, std::string offset) {
     std::string ret = "";
-    for (int j = 0; j < struct_var->get_member_count(); ++j) {
+    for (uint32_t j = 0; j < struct_var->get_member_count(); ++j) {
         std::shared_ptr<MemberExpr> member_expr;
         if  (parent_memb_expr != nullptr)
             member_expr = std::make_shared<MemberExpr>(parent_memb_expr, j);
@@ -146,7 +146,7 @@ std::string SymbolTable::emit_struct_check (std::string offset) {
 
 std::string SymbolTable::emit_single_struct_check (std::shared_ptr<MemberExpr> parent_memb_expr, std::shared_ptr<Struct> struct_var, std::string offset) {
     std::string ret = "";
-    for (int j = 0; j < struct_var->get_member_count(); ++j) {
+    for (uint32_t j = 0; j < struct_var->get_member_count(); ++j) {
         std::shared_ptr<MemberExpr> member_expr;
         if  (parent_memb_expr != nullptr)
             member_expr = std::make_shared<MemberExpr>(parent_memb_expr, j);

--- a/src/sym_table.h
+++ b/src/sym_table.h
@@ -39,11 +39,11 @@ class SymbolTable {
         void set_struct_types (std::vector<std::shared_ptr<StructType>> _struct_type) { struct_type = _struct_type; }
         void set_structs (std::vector<std::shared_ptr<Struct>> _structs) { structs = _structs; }
 
-        std::vector<std::shared_ptr<ScalarVariable>>& get_variables () { return variable; }
-        std::vector<std::shared_ptr<StructType>>& get_struct_types () { return struct_type; }
-        std::vector<std::shared_ptr<Struct>>& get_structs () { return structs; }
-        std::vector<std::shared_ptr<MemberExpr>>& get_avail_members() { return avail_members; }
-        std::vector<std::shared_ptr<MemberExpr>>& get_avail_const_members() { return avail_const_members; }
+        auto& get_variables () { return variable; }
+        auto& get_struct_types () { return struct_type; }
+        auto& get_structs () { return structs; }
+        auto& get_avail_members() { return avail_members; }
+        auto& get_avail_const_members() { return avail_const_members; }
         void del_avail_member(int idx) { avail_members.erase(avail_members.begin() + idx); }
 
         std::string emit_variable_extern_decl (std::string offset = "");
@@ -74,21 +74,21 @@ class Context {
         Context (GenPolicy _gen_policy, std::shared_ptr<Context> _parent_ctx, Node::NodeID _self_stmt_id, bool _taken);
 
         void set_gen_policy (GenPolicy _gen_policy) { gen_policy = std::make_shared<GenPolicy>(_gen_policy); }
-        std::shared_ptr<GenPolicy> get_gen_policy () { return gen_policy; }
+        auto get_gen_policy () { return gen_policy; }
         int get_depth () { return depth; }
         int get_if_depth () { return if_depth; }
-        Node::NodeID get_self_stmt_id () { return self_stmt_id; }
+        auto get_self_stmt_id () { return self_stmt_id; }
         bool get_taken () { return taken; }
-        void set_extern_inp_sym_table (std::shared_ptr<SymbolTable> _extern_inp_sym_table) { extern_inp_sym_table = _extern_inp_sym_table; }
-        std::shared_ptr<SymbolTable> get_extern_inp_sym_table () { return extern_inp_sym_table; }
-        void set_extern_out_sym_table (std::shared_ptr<SymbolTable> _extern_out_sym_table) { extern_out_sym_table = _extern_out_sym_table; }
-        std::shared_ptr<SymbolTable> get_extern_out_sym_table () { return extern_out_sym_table; }
-        void set_extern_mix_sym_table (std::shared_ptr<SymbolTable> _extern_mix_sym_table) { extern_mix_sym_table = _extern_mix_sym_table; }
-        std::shared_ptr<SymbolTable> get_extern_mix_sym_table () { return extern_mix_sym_table; }
+        void set_extern_inp_sym_table (std::shared_ptr<SymbolTable> st) { extern_inp_sym_table = st; }
+        auto get_extern_inp_sym_table () { return extern_inp_sym_table; }
+        void set_extern_out_sym_table (std::shared_ptr<SymbolTable> st) { extern_out_sym_table = st; }
+        auto get_extern_out_sym_table () { return extern_out_sym_table; }
+        void set_extern_mix_sym_table (std::shared_ptr<SymbolTable> st) { extern_mix_sym_table = st; }
+        auto get_extern_mix_sym_table () { return extern_mix_sym_table; }
 
-        std::shared_ptr<SymbolTable> get_local_sym_table () { return local_sym_table; }
+        auto get_local_sym_table () { return local_sym_table; }
         void set_local_sym_table (std::shared_ptr<SymbolTable> _lst) { local_sym_table = _lst; }
-        std::shared_ptr<Context> get_parent_ctx () { return parent_ctx; }
+        auto get_parent_ctx () { return parent_ctx; }
 
     private:
         std::shared_ptr<GenPolicy> gen_policy;

--- a/src/sym_table.h
+++ b/src/sym_table.h
@@ -75,8 +75,8 @@ class Context {
 
         void set_gen_policy (GenPolicy _gen_policy) { gen_policy = std::make_shared<GenPolicy>(_gen_policy); }
         auto get_gen_policy () { return gen_policy; }
-        int get_depth () { return depth; }
-        int get_if_depth () { return if_depth; }
+        uint32_t get_depth () { return depth; }
+        uint32_t get_if_depth () { return if_depth; }
         auto get_self_stmt_id () { return self_stmt_id; }
         bool get_taken () { return taken; }
         void set_extern_inp_sym_table (std::shared_ptr<SymbolTable> st) { extern_inp_sym_table = st; }
@@ -101,8 +101,8 @@ class Context {
         std::shared_ptr<Context> parent_ctx;
         std::shared_ptr<SymbolTable> local_sym_table;
         Node::NodeID self_stmt_id;
-        int if_depth;
-        int depth;
+        uint32_t if_depth;
+        uint32_t depth;
         bool taken;
         //TODO: maybe we should add taken member?
 };

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -1871,7 +1871,7 @@ void TypeULLINT::dbg_dump () {
 std::shared_ptr<BitField> BitField::generate (std::shared_ptr<Context> ctx, bool is_unnamed) {
     Type::CV_Qual cv_qual = ctx->get_gen_policy()->get_allowed_cv_qual().at(rand_val_gen->get_rand_value<int>(0,
                                                                                                                  ctx->get_gen_policy()->get_allowed_cv_qual().size() - 1));
-    IntegerType::IntegerTypeID int_type_id;
+    IntegerType::IntegerTypeID int_type_id = MAX_INT_ID;
     if (options->is_cxx())
         int_type_id = rand_val_gen->get_rand_id(ctx->get_gen_policy()->get_allowed_int_types());
     // In C without "J.5.8 Extended bit-field types" bit-filed can have only signed/unsigned int type
@@ -1967,11 +1967,11 @@ bool BitField::can_fit_in_int (BuiltinType::ScalarTypedVal val, bool is_unsigned
         if (is_unsigned)
             return (u_min <= u_val) && (u_val <= u_max);
         else
-            return (s_min <= u_val) && (u_val <= s_max);
+            return (u_val <= s_max);
     }
     else {
         if (is_unsigned)
-            return (u_min <= s_val) && (s_val <= u_max);
+            return ((int64_t)u_min <= s_val) && ((uint64_t)s_val <= u_max);
         else
             return (s_min <= s_val) && (s_val <= s_max);
     }

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -1162,7 +1162,7 @@ BuiltinType::ScalarTypedVal BuiltinType::ScalarTypedVal::operator<< (ScalarTyped
     BuiltinType::ScalarTypedVal ret = *this;
 
     int64_t s_lhs = 0;
-    uint64_t u_lhs = 0;
+//    uint64_t u_lhs = 0;
     int64_t s_rhs = 0;
     uint64_t u_rhs = 0;
     switch (int_type_id) {
@@ -1177,8 +1177,8 @@ BuiltinType::ScalarTypedVal BuiltinType::ScalarTypedVal::operator<< (ScalarTyped
             s_lhs = val.int_val;
             break;
         case IntegerType::IntegerTypeID::UINT:
-            u_lhs = val.uint_val;
-            break;
+//            u_lhs = val.uint_val;
+//            break;
         case IntegerType::IntegerTypeID::LINT:
             if (options->mode_64bit)
                 s_lhs = val.lint64_val;
@@ -1186,16 +1186,16 @@ BuiltinType::ScalarTypedVal BuiltinType::ScalarTypedVal::operator<< (ScalarTyped
                 s_lhs = val.lint32_val;
             break;
         case IntegerType::IntegerTypeID::ULINT:
-            if (options->mode_64bit)
-                u_lhs = val.ulint64_val;
-            else
-                u_lhs = val.ulint32_val;
+//            if (options->mode_64bit)
+//                u_lhs = val.ulint64_val;
+//            else
+//                u_lhs = val.ulint32_val;
             break;
         case IntegerType::IntegerTypeID::LLINT:
             s_lhs = val.llint_val;
             break;
         case IntegerType::IntegerTypeID::ULLINT:
-            u_lhs = val.ullint_val;
+//            u_lhs = val.ullint_val;
             break;
     }
 
@@ -1313,7 +1313,7 @@ BuiltinType::ScalarTypedVal BuiltinType::ScalarTypedVal::operator>> (ScalarTyped
     BuiltinType::ScalarTypedVal ret = *this;
 
     int64_t s_lhs = 0;
-    uint64_t u_lhs = 0;
+//    uint64_t u_lhs = 0;
     int64_t s_rhs = 0;
     uint64_t u_rhs = 0;
     switch (int_type_id) {
@@ -1328,7 +1328,7 @@ BuiltinType::ScalarTypedVal BuiltinType::ScalarTypedVal::operator>> (ScalarTyped
             s_lhs = val.int_val;
             break;
         case IntegerType::IntegerTypeID::UINT:
-            u_lhs = val.uint_val;
+//            u_lhs = val.uint_val;
             break;
         case IntegerType::IntegerTypeID::LINT:
             if (options->mode_64bit)
@@ -1337,16 +1337,16 @@ BuiltinType::ScalarTypedVal BuiltinType::ScalarTypedVal::operator>> (ScalarTyped
                 s_lhs = val.lint32_val;
             break;
         case IntegerType::IntegerTypeID::ULINT:
-            if (options->mode_64bit)
-                u_lhs = val.ulint64_val;
-            else
-                u_lhs = val.ulint32_val;
+//            if (options->mode_64bit)
+//                u_lhs = val.ulint64_val;
+//            else
+//                u_lhs = val.ulint32_val;
             break;
         case IntegerType::IntegerTypeID::LLINT:
             s_lhs = val.llint_val;
             break;
         case IntegerType::IntegerTypeID::ULLINT:
-            u_lhs = val.ullint_val;
+//            u_lhs = val.ullint_val;
             break;
     }
 
@@ -1967,7 +1967,7 @@ bool BitField::can_fit_in_int (BuiltinType::ScalarTypedVal val, bool is_unsigned
         if (is_unsigned)
             return (u_min <= u_val) && (u_val <= u_max);
         else
-            return (u_val <= s_max);
+            return (u_val <= (uint64_t)s_max);
     }
     else {
         if (is_unsigned)

--- a/src/type.h
+++ b/src/type.h
@@ -72,7 +72,7 @@ class Type {
         };
 
         Type (TypeID _id) : cv_qual(CV_Qual::NTHG), is_static(false), align(0), id (_id) {}
-        Type (TypeID _id, CV_Qual _cv_qual, bool _is_static, uint64_t _align) :
+        Type (TypeID _id, CV_Qual _cv_qual, bool _is_static, uint32_t _align) :
               cv_qual (_cv_qual), is_static (_is_static), align (_align), id (_id) {}
 
         // Getters and setters for general Type properties
@@ -85,8 +85,8 @@ class Type {
         CV_Qual get_cv_qual () { return cv_qual; }
         void set_is_static (bool _is_static) { is_static = _is_static; }
         bool get_is_static () { return is_static; }
-        void set_align (uint64_t _align) { align = _align; }
-        uint64_t get_align () { return align; }
+        void set_align (uint32_t _align) { align = _align; }
+        uint32_t get_align () { return align; }
 
         // We assume static storage duration, cv-qualifier and alignment as a part of Type's full name
         std::string get_name ();
@@ -106,7 +106,7 @@ class Type {
         std::string name;
         CV_Qual cv_qual;
         bool is_static;
-        uint64_t align;
+        uint32_t align;
 
     private:
         TypeID id;
@@ -133,7 +133,7 @@ class StructType : public Type {
         };
 
         StructType (std::string _name) : Type (Type::STRUCT_TYPE), nest_depth(0) { name = _name; }
-        StructType (std::string _name, CV_Qual _cv_qual, bool _is_static, uint64_t _align) :
+        StructType (std::string _name, CV_Qual _cv_qual, bool _is_static, uint32_t _align) :
                     Type (Type::STRUCT_TYPE, _cv_qual, _is_static, _align), nest_depth(0) { name = _name; }
         bool is_struct_type() { return true; }
 
@@ -142,9 +142,9 @@ class StructType : public Type {
         void add_member (std::shared_ptr<StructMember> new_mem) { members.push_back(new_mem); shadow_members.push_back(new_mem); }
         void add_member (std::shared_ptr<Type> _type, std::string _name);
         void add_shadow_member (std::shared_ptr<Type> _type) { shadow_members.push_back(std::make_shared<StructMember>(_type, "")); }
-        uint64_t get_member_count () { return members.size(); }
-        uint64_t get_shadow_member_count () { return shadow_members.size(); }
-        uint64_t get_nest_depth () { return nest_depth; }
+        uint32_t get_member_count () { return members.size(); }
+        uint32_t get_shadow_member_count () { return shadow_members.size(); }
+        uint32_t get_nest_depth () { return nest_depth; }
         std::shared_ptr<StructMember> get_member (unsigned int num);
 
 
@@ -162,7 +162,7 @@ class StructType : public Type {
         //TODO: it is a stub for unnamed bit fields. Nobody should know about them
         std::vector<std::shared_ptr<StructMember>> shadow_members;
         std::vector<std::shared_ptr<StructMember>> members;
-        uint64_t nest_depth;
+        uint32_t nest_depth;
 };
 
 // ID for all handled Undefined Behaviour
@@ -259,13 +259,13 @@ class BuiltinType : public Type {
         };
 
         BuiltinType (BuiltinTypeID _builtin_id) : Type (Type::BUILTIN_TYPE), bit_size (0), suffix(""), builtin_id (_builtin_id) {}
-        BuiltinType (BuiltinTypeID _builtin_id, CV_Qual _cv_qual, bool _is_static, uint64_t _align) :
+        BuiltinType (BuiltinTypeID _builtin_id, CV_Qual _cv_qual, bool _is_static, uint32_t _align) :
                     Type (Type::BUILTIN_TYPE, _cv_qual, _is_static, _align), bit_size (0), suffix(""), builtin_id (_builtin_id) {}
         bool is_builtin_type() { return true; }
 
         // Getters for BuiltinType properties
         BuiltinTypeID get_builtin_type_id() { return builtin_id; }
-        uint64_t get_bit_size () { return bit_size; }
+        uint32_t get_bit_size () { return bit_size; }
         std::string get_suffix () { return suffix; }
 
     protected:
@@ -283,7 +283,7 @@ std::ostream& operator<< (std::ostream &out, const BuiltinType::ScalarTypedVal &
 class IntegerType : public BuiltinType {
     public:
         IntegerType (IntegerTypeID it_id) : BuiltinType (BuiltinTypeID::Integer), is_signed (false), min(it_id), max(it_id), int_type_id (it_id) {}
-        IntegerType (IntegerTypeID it_id, CV_Qual _cv_qual, bool _is_static, uint64_t _align) :
+        IntegerType (IntegerTypeID it_id, CV_Qual _cv_qual, bool _is_static, uint32_t _align) :
                      BuiltinType (BuiltinTypeID::Integer, _cv_qual, _is_static, _align),
                      is_signed (false), min(it_id), max(it_id), int_type_id (it_id) {}
         bool is_int_type() { return true; }
@@ -296,7 +296,7 @@ class IntegerType : public BuiltinType {
 
         // This utility functions take IntegerTypeID and return shared pointer to corresponding type
         static std::shared_ptr<IntegerType> init (BuiltinType::IntegerTypeID _type_id);
-        static std::shared_ptr<IntegerType> init (BuiltinType::IntegerTypeID _type_id, CV_Qual _cv_qual, bool _is_static, uint64_t _align);
+        static std::shared_ptr<IntegerType> init (BuiltinType::IntegerTypeID _type_id, CV_Qual _cv_qual, bool _is_static, uint32_t _align);
 
         // If type A can represent all the values of type B
         static bool can_repr_value (BuiltinType::IntegerTypeID A, BuiltinType::IntegerTypeID B); // if type B can represent all of the values of the type A
@@ -319,12 +319,12 @@ class IntegerType : public BuiltinType {
 // Class which represents bit-field
 class BitField : public IntegerType {
     public:
-        BitField (IntegerTypeID it_id, uint64_t _bit_size) : IntegerType(it_id) { init_type(it_id, _bit_size); }
-        BitField (IntegerTypeID it_id, uint64_t _bit_size, CV_Qual _cv_qual) : IntegerType(it_id, _cv_qual, false, 0) { init_type(it_id, _bit_size); }
+        BitField (IntegerTypeID it_id, uint32_t _bit_size) : IntegerType(it_id) { init_type(it_id, _bit_size); }
+        BitField (IntegerTypeID it_id, uint32_t _bit_size, CV_Qual _cv_qual) : IntegerType(it_id, _cv_qual, false, 0) { init_type(it_id, _bit_size); }
 
         // Getters of BitField properties
         bool get_is_bit_field() { return true; }
-        uint64_t get_bit_field_width() { return bit_field_width; }
+        uint32_t get_bit_field_width() { return bit_field_width; }
 
         // If all values of the bit-field can fit in signed/unsigned int
         static bool can_fit_in_int (BuiltinType::ScalarTypedVal val, bool is_unsigned);
@@ -336,8 +336,8 @@ class BitField : public IntegerType {
 
     private:
         // Common initializer functions, used in constructors
-        void init_type(IntegerTypeID it_id, uint64_t _bit_size);
-        uint64_t bit_field_width;
+        void init_type(IntegerTypeID it_id, uint32_t _bit_size);
+        uint32_t bit_field_width;
 };
 
 // Following classes represents standard integer types and bool
@@ -345,7 +345,7 @@ class BitField : public IntegerType {
 class TypeBOOL : public IntegerType {
     public:
         TypeBOOL () : IntegerType(BuiltinType::IntegerTypeID::BOOL) { init_type (); }
-        TypeBOOL (CV_Qual _cv_qual, bool _is_static, uint64_t _align) :
+        TypeBOOL (CV_Qual _cv_qual, bool _is_static, uint32_t _align) :
                   IntegerType(BuiltinType::IntegerTypeID::BOOL, _cv_qual, _is_static, _align) { init_type (); }
         void dbg_dump ();
 
@@ -363,7 +363,7 @@ class TypeBOOL : public IntegerType {
 class TypeCHAR : public IntegerType {
     public:
         TypeCHAR () : IntegerType(BuiltinType::IntegerTypeID::CHAR) { init_type (); }
-        TypeCHAR (CV_Qual _cv_qual, bool _is_static, uint64_t _align) :
+        TypeCHAR (CV_Qual _cv_qual, bool _is_static, uint32_t _align) :
                   IntegerType(BuiltinType::IntegerTypeID::CHAR, _cv_qual, _is_static, _align) { init_type (); }
         void dbg_dump ();
 
@@ -381,7 +381,7 @@ class TypeCHAR : public IntegerType {
 class TypeUCHAR : public IntegerType {
     public:
         TypeUCHAR () : IntegerType(BuiltinType::IntegerTypeID::UCHAR) { init_type (); }
-        TypeUCHAR (CV_Qual _cv_qual, bool _is_static, uint64_t _align) :
+        TypeUCHAR (CV_Qual _cv_qual, bool _is_static, uint32_t _align) :
                    IntegerType(BuiltinType::IntegerTypeID::UCHAR, _cv_qual, _is_static, _align) { init_type (); }
         void dbg_dump ();
 
@@ -399,7 +399,7 @@ class TypeUCHAR : public IntegerType {
 class TypeSHRT : public IntegerType {
     public:
         TypeSHRT () : IntegerType(BuiltinType::IntegerTypeID::SHRT) { init_type (); }
-        TypeSHRT (CV_Qual _cv_qual, bool _is_static, uint64_t _align) :
+        TypeSHRT (CV_Qual _cv_qual, bool _is_static, uint32_t _align) :
                   IntegerType(BuiltinType::IntegerTypeID::SHRT, _cv_qual, _is_static, _align) { init_type (); }
         void dbg_dump ();
 
@@ -417,7 +417,7 @@ class TypeSHRT : public IntegerType {
 class TypeUSHRT : public IntegerType {
     public:
         TypeUSHRT () : IntegerType(BuiltinType::IntegerTypeID::USHRT) { init_type (); }
-        TypeUSHRT (CV_Qual _cv_qual, bool _is_static, uint64_t _align) :
+        TypeUSHRT (CV_Qual _cv_qual, bool _is_static, uint32_t _align) :
                    IntegerType(BuiltinType::IntegerTypeID::USHRT, _cv_qual, _is_static, _align) { init_type (); }
         void dbg_dump ();
 
@@ -435,7 +435,7 @@ class TypeUSHRT : public IntegerType {
 class TypeINT : public IntegerType {
     public:
         TypeINT () : IntegerType(BuiltinType::IntegerTypeID::INT) { init_type (); }
-        TypeINT (CV_Qual _cv_qual, bool _is_static, uint64_t _align) :
+        TypeINT (CV_Qual _cv_qual, bool _is_static, uint32_t _align) :
                  IntegerType(BuiltinType::IntegerTypeID::INT, _cv_qual, _is_static, _align) { init_type (); }
         void dbg_dump ();
 
@@ -453,7 +453,7 @@ class TypeINT : public IntegerType {
 class TypeUINT : public IntegerType {
     public:
         TypeUINT () : IntegerType(BuiltinType::IntegerTypeID::UINT) { init_type (); }
-        TypeUINT (CV_Qual _cv_qual, bool _is_static, uint64_t _align) :
+        TypeUINT (CV_Qual _cv_qual, bool _is_static, uint32_t _align) :
                   IntegerType(BuiltinType::IntegerTypeID::UINT, _cv_qual, _is_static, _align) { init_type (); }
         void dbg_dump ();
 
@@ -471,7 +471,7 @@ class TypeUINT : public IntegerType {
 class TypeLINT : public IntegerType {
     public:
         TypeLINT () : IntegerType(BuiltinType::IntegerTypeID::LINT) { init_type (); }
-        TypeLINT (CV_Qual _cv_qual, bool _is_static, uint64_t _align) :
+        TypeLINT (CV_Qual _cv_qual, bool _is_static, uint32_t _align) :
                   IntegerType(BuiltinType::IntegerTypeID::LINT, _cv_qual, _is_static, _align) { init_type (); }
         void dbg_dump ();
 
@@ -496,7 +496,7 @@ class TypeLINT : public IntegerType {
 class TypeULINT : public IntegerType {
     public:
         TypeULINT () : IntegerType(BuiltinType::IntegerTypeID::ULINT) { init_type (); }
-        TypeULINT (CV_Qual _cv_qual, bool _is_static, uint64_t _align) :
+        TypeULINT (CV_Qual _cv_qual, bool _is_static, uint32_t _align) :
                    IntegerType(BuiltinType::IntegerTypeID::ULINT, _cv_qual, _is_static, _align) { init_type (); }
         void dbg_dump ();
 
@@ -521,7 +521,7 @@ class TypeULINT : public IntegerType {
 class TypeLLINT : public IntegerType {
     public:
         TypeLLINT () : IntegerType(BuiltinType::IntegerTypeID::LLINT) { init_type (); }
-        TypeLLINT (CV_Qual _cv_qual, bool _is_static, uint64_t _align) :
+        TypeLLINT (CV_Qual _cv_qual, bool _is_static, uint32_t _align) :
                    IntegerType(BuiltinType::IntegerTypeID::LLINT, _cv_qual, _is_static, _align) { init_type (); }
         void dbg_dump ();
 
@@ -539,7 +539,7 @@ class TypeLLINT : public IntegerType {
 class TypeULLINT : public IntegerType {
     public:
         TypeULLINT () : IntegerType(BuiltinType::IntegerTypeID::ULLINT) { init_type (); }
-        TypeULLINT (CV_Qual _cv_qual, bool _is_static, uint64_t _align) :
+        TypeULLINT (CV_Qual _cv_qual, bool _is_static, uint32_t _align) :
                     IntegerType(BuiltinType::IntegerTypeID::ULLINT, _cv_qual, _is_static, _align) { init_type (); }
         void dbg_dump ();
 

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -26,7 +26,7 @@ using namespace yarpgen;
 void Struct::allocate_members() {
     std::shared_ptr<StructType> struct_type = std::static_pointer_cast<StructType>(type);
     // TODO: struct member can be not only integer
-    for (int i = 0; i < struct_type->get_member_count(); ++i) {
+    for (uint32_t i = 0; i < struct_type->get_member_count(); ++i) {
         std::shared_ptr<StructType::StructMember> cur_member = struct_type->get_member(i);
         if (cur_member->get_type()->is_int_type()) {
             if (struct_type->get_member(i)->get_type()->get_is_static()) {
@@ -89,7 +89,7 @@ std::shared_ptr<Struct> Struct::generate (std::shared_ptr<Context> ctx, std::sha
 }
 
 void Struct::generate_members_init(std::shared_ptr<Context> ctx) {
-    for (int i = 0; i < get_member_count(); ++i) {
+    for (uint32_t i = 0; i < get_member_count(); ++i) {
         if (get_member(i)->get_type()->is_struct_type()) {
             std::static_pointer_cast<Struct>(get_member(i))->generate_members_init(ctx);
         }

--- a/test_sets.txt
+++ b/test_sets.txt
@@ -51,35 +51,37 @@ Testing sets:
 
 # Set name       | Spec name   | Arguments | Compiler arch  | Sde arch
 ubsan_clang_o0   | ubsan_clang | -O0       |                |
-#ubsan_clang_o2  | ubsan_clang | -O2       |                |
+#ubsan_clang_o2   | ubsan_clang | -O2       |                |
 ubsan_gcc_o0     | ubsan_gcc   | -O0       |                |
-#ubsan_gcc_o2    | ubsan_gcc   | -O2       |                |
+#ubsan_gcc_o2     | ubsan_gcc   | -O2       |                |
 
-gcc_no_opt       | gcc       | -O0       | nehalem        | nhm
-gcc_wsm_opt      | gcc       | -O3       | westmere       | wsm
-gcc_ivb_opt      | gcc       | -O3       | ivybridge      | ivb
-gcc_bdw_opt      | gcc       | -O3       | broadwell      | bdw
-gcc_knl_no_opt   | gcc       | -O0       | knl            | knl
-gcc_knl_opt      | gcc       | -O3       | knl            | knl
-gcc_skx_no_opt   | gcc       | -O0       | skylake-avx512 | skx
-gcc_skx_opt      | gcc       | -O3       | skylake-avx512 | skx
+gcc_no_opt       | gcc       | -O0       |                |
+gcc_opt          | gcc       | -O3       |                |
+#gcc_wsm_opt      | gcc       | -O3       | westmere       | wsm
+#gcc_ivb_opt      | gcc       | -O3       | ivybridge      | ivb
+#gcc_hsw_opt      | gcc       | -O3       | haswell        | hsw
+#gcc_bdw_opt      | gcc       | -O3       | broadwell      | bdw
+#gcc_knl_no_opt   | gcc       | -O0       | knl            | knl
+#gcc_knl_opt      | gcc       | -O3       | knl            | knl
+#gcc_skx_no_opt   | gcc       | -O0       | skylake-avx512 | skx
+#gcc_skx_opt      | gcc       | -O3       | skylake-avx512 | skx
 
 clang_no_opt     | clang     | -O0       |                |
 clang_opt        | clang     | -O3       |                |
-clang_knl_no_opt | clang     | -O0       | knl            | knl
-clang_knl_opt    | clang     | -O3       | knl            | knl
-clang_skx_no_opt | clang     | -O0       | skx            | skx
-clang_skx_opt    | clang     | -O3       | skx            | skx
+#clang_knl_no_opt | clang     | -O0       | knl            | knl
+#clang_knl_opt    | clang     | -O3       | knl            | knl
+#clang_skx_no_opt | clang     | -O0       | skx            | skx
+#clang_skx_opt    | clang     | -O3       | skx            | skx
 
 icc_no_opt       | icc       | -O0       |                |
 icc_opt          | icc       | -O3       |                |
-icc_knl_no_opt   | icc       | -O0       | MIC-AVX512     | knl
-icc_knl_opt      | icc       | -O3       | MIC-AVX512     | knl
-icc_skx_no_opt   | icc       | -O0       | CORE-AVX512    | skx
-icc_skx_opt      | icc       | -O3       | CORE-AVX512    | skx
+#icc_knl_no_opt   | icc       | -O0       | MIC-AVX512     | knl
+#icc_knl_opt      | icc       | -O3       | MIC-AVX512     | knl
+#icc_skx_no_opt   | icc       | -O0       | CORE-AVX512    | skx
+#icc_skx_opt      | icc       | -O3       | CORE-AVX512    | skx
 
 icx_no_opt       | icx       | -O0       |                |
-icx_hsw_opt      | icx       | -O3       |                | hsw
+icx_opt          | icx       | -O3       |                |
 
 Options for statistics' capture:
 #Spec name  | Arguments


### PR DESCRIPTION
Bunch of clean up changes:
- fix build on MacOS
- fix build with gcc
- fix gcc warnings
- convert a lot of "num" and "count" variables to un unsigned types
- a bit of C++14 features usage to improve the code readability
- change default settings for compiler options to be hardware neutral