### PR TITLE
Minor fixes

### DIFF
--- a/run_gen.py
+++ b/run_gen.py
@@ -76,6 +76,11 @@ known_build_fails = { \
     "verify_gimple_shift": "type mismatch in shift expression", \
     "verify_gimple_binary": "type mismatch in binary expression", \
     "REG_BR_PROB": "REG_BR_PROB does not match", \
+    "build_low_bits_mask": "in build_low_bits_mask", \
+    "verify_gimple_conversion_in_unary": "non-trivial conversion in unary operation", \
+    "verify_gimple_register_size": "conversion of register to a different size", \
+    "decompose": "in decompose", \
+    "verify_gimple_unary_conversion": "mismatching comparison operand types", \
 # problem with available memory
     "memory_problem": "std::bad_alloc", \
     "memory_problem": "Cannot allocate memory" \
@@ -686,7 +691,7 @@ class Test(object):
         # This is needed when reduceing gcc_ubsan problem. Without this check we have good chances to reduce to the code
         # snipent, which contains left shift of negative value (caught by gcc ubsan, but not clang ubsan).
         test_sh +="! grep \"left shift of negative value\" err.log && \\\n"
-        
+
         test_sh +="make -f $TEST_PWD" + os.sep + creduce_makefile_name + " " + ubsan_run.optset + " && \\\n"
         test_sh +="make -f $TEST_PWD" + os.sep + creduce_makefile_name + " run_" + ubsan_run.optset + " \n"
         test_sh_file = open("test.sh", "w")

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -40,9 +40,8 @@ std::shared_ptr<Data> Expr::get_value () {
         }
         case Data::VarClassID::MAX_CLASS_ID:
             ERROR("unsupported Data::VarClassID (Expr)");
-        default:
-            ERROR("Expr::get_value() - data corruption");
     }
+    ERROR("Expr::get_value() - data corruption");
 }
 
 std::shared_ptr<Expr> VarUseExpr::set_value (std::shared_ptr<Expr> _expr) {
@@ -62,9 +61,8 @@ std::shared_ptr<Expr> VarUseExpr::set_value (std::shared_ptr<Expr> _expr) {
             break;
         case Data::VarClassID::MAX_CLASS_ID:
             ERROR("unsupported Data::VarClassID (VarUseExpr)");
-        default:
-            ERROR("Expr::set_value() - data corruption");
     }
+    ERROR("Expr::set_value() - data corruption");
 }
 
 VarUseExpr::VarUseExpr(std::shared_ptr<Data> _var) : Expr(Node::NodeID::VAR_USE, _var) {
@@ -994,9 +992,8 @@ std::shared_ptr<Expr> MemberExpr::set_value (std::shared_ptr<Expr> _expr) {
             break;
         case Data::VarClassID::MAX_CLASS_ID:
             ERROR("unsupported Data::VarClassID (MemberExpr)");
-        default:
-            ERROR("MemberExpr::set_value() - data corruption");
     }
+    ERROR("MemberExpr::set_value() - data corruption");
 }
 
 static std::shared_ptr<Expr> change_to_value(std::shared_ptr<Context> ctx, std::shared_ptr<Expr> _expr, BuiltinType::ScalarTypedVal to_val) {

--- a/src/master.cpp
+++ b/src/master.cpp
@@ -106,9 +106,8 @@ std::string Master::emit_decl () {
 std::string Master::emit_func () {
     std::string ret = "";
     ret += "#include \"init.h\"\n\n";
-    ret += "void foo () {\n";
+    ret += "void foo ()\n";
     ret += program->emit();
-    ret += "}";
     write_file("func." + get_file_ext(), ret);
     return ret;
 }

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -1178,7 +1178,7 @@ BuiltinType::ScalarTypedVal BuiltinType::ScalarTypedVal::operator<< (ScalarTyped
             break;
         case IntegerType::IntegerTypeID::UINT:
 //            u_lhs = val.uint_val;
-//            break;
+            break;
         case IntegerType::IntegerTypeID::LINT:
             if (options->mode_64bit)
                 s_lhs = val.lint64_val;


### PR DESCRIPTION
- Add some more known gcc fails
- Avoid defaults in swithes
- Fix mistakenly commented break
- Avoid double curly braces in foo()